### PR TITLE
feat: add http2

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -8,7 +8,7 @@ let
     extraConfig = ''
       location / {
         default_type application/json;
-        return 200 '{"remote_addr":"$remote_addr","service": "${svcName}","tls":false}';
+        return 200 '{"remote_addr":"$remote_addr","service": "${svcName}","tls":false,"protocol":"$server_protocol"}';
       }
     '';
   };
@@ -25,7 +25,7 @@ let
         if ($ssl_protocol) {
           set $tls_flag true;
         }
-        return 200 '{"remote_addr":"$remote_addr","service":"${svcName}","tls":$tls_flag}';
+        return 200 '{"remote_addr":"$remote_addr","service":"${svcName}","tls":$tls_flag,"protocol":"$server_protocol"}';
       }
     '';
   };
@@ -122,13 +122,21 @@ in
       result = json.loads(node.succeed(
         "curl --fail --socks5 127.0.0.1:8080 http://hello.corp.example.com"
       ))
-      assert result['service'] == 'hello.corp' and result['remote_addr'] == self_ip, "Unexpected result from the web service: {}".format(json.dumps(result))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] == self_ip
+        and result['protocol'] == 'HTTP/1.1'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
 
       # This exercise the SOCKS5 DNS resolution.
       result = json.loads(node.succeed(
         "curl --fail --socks5-hostname 127.0.0.1:8080 http://hello.corp.example.com"
       ))
-      assert result['service'] == 'hello.corp' and result['remote_addr'] == self_ip, "Unexpected result from the web service: {}".format(json.dumps(result))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] == self_ip
+        and result['protocol'] == 'HTTP/1.1'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
 
       # TODO: test downstream TLS via SOCKS5.
 
@@ -137,26 +145,81 @@ in
       result = json.loads(node.succeed(
         "curl --fail --proxytunnel --proxy http://127.0.0.1:8080 http://hello.corp.example.com"
       ))
-      assert result['service'] == 'hello.corp' and result['remote_addr'] == self_ip and not result['tls'], "Unexpected result from the web service: {}".format(json.dumps(result))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] == self_ip
+        and not result['tls']
+        and result['protocol'] == 'HTTP/1.1'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
+
+      # No --proxytunnel since curl uses CONNECT by default for HTTPS
       result = json.loads(node.succeed(
-        "curl --fail --proxytunnel --proxy http://127.0.0.1:8080 https://hello.corp.example.com"
+        "curl --fail --proxy http://127.0.0.1:8080 https://hello.corp.example.com"
       ))
-      assert result['service'] == 'hello.corp' and result['remote_addr'] == self_ip and result['tls'], "Unexpected result from the web service: {}".format(json.dumps(result))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] == self_ip
+        and result['tls']
+        and result['protocol'] == 'HTTP/2.0'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
 
       # Test HTTPS CONNECT
       # --proxytunnel will force HTTPS CONNECT
       result = json.loads(node.succeed(
         "curl --fail --proxytunnel --proxy https://${portailDomain}:8080 http://hello.corp.example.com"
-      )) 
-      assert result['service'] == 'hello.corp' and result['remote_addr'] == self_ip and not result['tls'], "Unexpected result from the web service: {}".format(json.dumps(result))
+      ))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] == self_ip
+        and not result['tls']
+        and result['protocol'] == 'HTTP/1.1'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
 
       # FIXME: TLS over TLS is not cleaning up properly the tunnel.
       # node # [   15.560560] portail[623]: 2026-03-05T00:43:56.909060Z ERROR portail::proxy::http_connect: CONNECT tunnel error: peer closed connection without sending TLS close_notify: https://docs.rs/rustls/latest/rustls/manual/_03_howto/index.html#unexpected-eof
       # The curl succeeds but the next assertion fails.
       result = json.loads(node.succeed(
-        "curl --fail --proxytunnel --proxy https://${portailDomain}:8080 https://hello.corp.example.com"
-      )) 
-      assert result['service'] == 'hello.corp' and result['remote_addr'] == self_ip and result['tls'], "Unexpected result from the web service: {}".format(json.dumps(result))
+        "curl --fail --proxy https://${portailDomain}:8080 https://hello.corp.example.com"
+      ))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] == self_ip
+        and result['tls']
+        and result['protocol'] == 'HTTP/2.0'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
+
+      # Test HTTP2 CONNECT
+      # --proxy-http2 will force HTTP2 CONNECT
+      result = json.loads(node.succeed(
+        "curl --fail --proxy-http2 --proxy https://${portailDomain}:8080 https://hello.corp.example.com"
+      ))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] == self_ip
+        and result['tls']
+        and result['protocol'] == 'HTTP/2.0'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
+
+      # Test HTTP2 CONNECT multiplexing
+      # For curl to multiplex requests, we have to:
+      # - add --parallel
+      # - add multiple requests with the same domain
+      node.succeed(
+        "curl --fail --trace-ascii /tmp/multiplex-trace --proxy-http2 --parallel --proxy https://${portailDomain}:8080 -o /tmp/multiplex-out1 -o /tmp/multiplex-out2 https://hello.corp.example.com https://hello.corp.example.com"
+      )
+      for i in ["1", "2"]:
+        result = json.loads(node.succeed("cat /tmp/multiplex-out" + i))
+        assert (
+          result['service'] == 'hello.corp'
+          and result['remote_addr'] == self_ip
+          and result['tls']
+          and result['protocol'] == 'HTTP/2.0'
+        ), "Unexpected result from multiplexed request {}: {}".format(i, json.dumps(result))
+      curl_trace = node.succeed("cat /tmp/multiplex-trace")
+      assert "Multiplexed connection found" in curl_trace, "Expected 'Multiplexed connection found', got: " + curl_trace
+      # Note: this string might change between curl versions
+      assert "Reusing existing https: connection with proxy portail.corp.example.com" in curl_trace, "Expected 'Reusing existing https: connection with proxy portail.corp.example.com', got: " + curl_trace
+
 
       # This exercises rejections and ACLs.
       # TODO: once ACLs are stabilized, uncomment.
@@ -247,12 +310,20 @@ in
       result = json.loads(node.succeed(
         "curl --fail --socks5 127.0.0.1:8080 http://hello.corp.example.com"
       ))
-      assert result['service'] == 'hello.corp' and result['remote_addr'] != self_ip, "Unexpected result from the web service: {}".format(json.dumps(result))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] != self_ip
+        and result['protocol'] == 'HTTP/1.1'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
       # This exercise the SOCKS5 DNS resolution.
       result = json.loads(node.succeed(
         "curl --fail --socks5-hostname 127.0.0.1:8080 http://hello.corp.example.com"
       ))
-      assert result['service'] == 'hello.corp' and result['remote_addr'] != self_ip, "Unexpected result from the web service: {}".format(json.dumps(result))
+      assert (
+        result['service'] == 'hello.corp'
+        and result['remote_addr'] != self_ip
+        and result['protocol'] == 'HTTP/1.1'
+      ), "Unexpected result from the web service: {}".format(json.dumps(result))
     '';
   };
 
@@ -347,6 +418,7 @@ in
       assert (
         result['service'] == 'hello.corp'
         and result['remote_addr'] != self_ip
+        and result['protocol'] == 'HTTP/1.1'
       ), "Unexpected result from the web service: {}".format(json.dumps(result))
     '';
   };

--- a/src/proxy/client_tls.rs
+++ b/src/proxy/client_tls.rs
@@ -1,8 +1,14 @@
 use std::sync::Arc;
 
-use tokio::{io::{AsyncRead, AsyncWrite}, sync::RwLock};
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::RwLock,
+};
 
-use tokio_rustls::{TlsConnector, TlsStream, rustls::{ClientConfig, pki_types::ServerName}};
+use tokio_rustls::{
+    TlsConnector, TlsStream,
+    rustls::{ClientConfig, pki_types::ServerName},
+};
 use tracing::debug;
 
 /// This connects to a target server using a mTLS mechanism.
@@ -16,11 +22,12 @@ pub async fn connect_using_tls_auth<IO: AsyncRead + AsyncWrite + Unpin>(
     stream: IO,
     domain: ServerName<'static>,
     state: Arc<RwLock<crate::state::State>>,
+    alpn_protocols: Vec<Vec<u8>>,
 ) -> Result<TlsStream<IO>, tokio::io::Error> {
     let config = {
         let state = state.read().await;
 
-        match (state.root_store.clone(), state.client_cert_resolver.clone()) {
+        let mut config = match (state.root_store.clone(), state.client_cert_resolver.clone()) {
             (Some(root_store), Some(cert_resolver)) => ClientConfig::builder()
                 .with_root_certificates(root_store)
                 .with_client_cert_resolver(cert_resolver),
@@ -28,11 +35,17 @@ pub async fn connect_using_tls_auth<IO: AsyncRead + AsyncWrite + Unpin>(
                 .with_root_certificates(root_store)
                 .with_no_client_auth(),
             (None, Some(_)) => {
-                return Err(tokio::io::Error::new(tokio::io::ErrorKind::Other, "Client auth set without roots"));
+                return Err(tokio::io::Error::new(
+                    tokio::io::ErrorKind::Other,
+                    "Client auth set without roots",
+                ));
             }
             // TODO: configure with default webpki
-            (None, None) => panic!("webpki setup")
-        }
+            (None, None) => panic!("webpki setup"),
+        };
+
+        config.alpn_protocols = alpn_protocols;
+        config
     };
 
     let connector = TlsConnector::from(Arc::new(config));

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -1,3 +1,4 @@
+use crate::proxy::protocol_detect::{ALPN_H2, ALPN_HTTP1_1};
 use crate::{
     config::{BackendSettings, Settings},
     proxy::{ProxyError, client_tls, context::RequestContext},
@@ -8,7 +9,7 @@ use http_body_util::{BodyExt, Empty, combinators::BoxBody};
 use hyper::{
     Method, Request, Response, StatusCode,
     body::Incoming,
-    header::{self, HeaderValue},
+    header,
     server::conn::{http1, http2},
     service::service_fn,
 };
@@ -26,6 +27,11 @@ trait OutboundStreamIo: AsyncRead + AsyncWrite {}
 impl<T: AsyncRead + AsyncWrite> OutboundStreamIo for T {}
 
 type OutboundStream = Box<dyn OutboundStreamIo + Send + Unpin>;
+
+enum InboundHttpProtocol {
+    Http1,
+    Http2,
+}
 
 /// References:
 /// - https://docs.rs/hyper/latest/hyper/upgrade/index.html
@@ -45,7 +51,13 @@ pub async fn serve_http1_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
         .serve_connection(
             io,
             service_fn(move |req| {
-                handle_http_request(req, ctx.clone(), settings.clone(), state.clone())
+                handle_http_request(
+                    req,
+                    ctx.clone(),
+                    settings.clone(),
+                    state.clone(),
+                    InboundHttpProtocol::Http1,
+                )
             }),
         )
         .with_upgrades()
@@ -72,7 +84,13 @@ pub async fn serve_http2_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
         .serve_connection(
             io,
             service_fn(move |req| {
-                handle_http_request(req, ctx.clone(), settings.clone(), state.clone())
+                handle_http_request(
+                    req,
+                    ctx.clone(),
+                    settings.clone(),
+                    state.clone(),
+                    InboundHttpProtocol::Http2,
+                )
             }),
         )
         .await
@@ -86,6 +104,7 @@ async fn handle_http_request(
     mut ctx: RequestContext,
     settings: Arc<Settings>,
     state: Arc<RwLock<State>>,
+    inbound_protocol: InboundHttpProtocol,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     if req.method() != Method::CONNECT {
         debug!(
@@ -156,7 +175,14 @@ async fn handle_http_request(
             "Backend {} selected for HTTP CONNECT to {}",
             backend.target_address, final_address
         );
-        match connect_to_http_proxy_backend(backend, &final_address, state.clone()).await {
+        match connect_to_http_proxy_backend(
+            backend,
+            &final_address,
+            state.clone(),
+            &inbound_protocol,
+        )
+        .await
+        {
             Ok(upstream) => {
                 stream = Some(upstream);
                 break;
@@ -198,12 +224,11 @@ async fn handle_http_request(
         }
     });
 
+    // Connection: keep-alive is
+    // - the default for HTTP/1.1
+    // - stripped by hyper for HTTP/2 https://github.com/hyperium/hyper/blob/e13e783927d429fc03038fe512eeb4d379cf1a70/src/proto/h2/mod.rs#L43
     let mut resp = Response::new(empty_body());
     *resp.status_mut() = StatusCode::OK;
-    resp.headers_mut().insert(
-        hyper::header::CONNECTION,
-        HeaderValue::from_static("keep-alive"),
-    );
 
     Ok(resp)
 }
@@ -216,14 +241,20 @@ fn empty_body() -> BoxBody<Bytes, hyper::Error> {
 
 /// Send CONNECT and return the stream on 2xx response
 /// Ref: https://github.com/hyperium/hyper/blob/master/examples/client.rs
+///
+/// When upstream uses TLS, ALPN is ordered by inbound protocol:
+/// - Client HTTP/1.1 → [http/1.1, h2]
+/// - Client HTTP/2 → [h2, http/1.1]
+/// When upstream is plain TCP, HTTP/1.1 is used.
 async fn connect_to_http_proxy_backend(
     backend: &BackendSettings,
     final_address: &str,
     state: Arc<RwLock<State>>,
+    inbound_protocol: &InboundHttpProtocol,
 ) -> io::Result<OutboundStream> {
     let socket = TcpStream::connect(backend.target_address).await?;
 
-    let stream: OutboundStream = if backend.identity_aware {
+    let (stream, use_http2): (OutboundStream, bool) = if backend.identity_aware {
         debug!(
             "Backend is identity-aware, establishing a TLS connection to {}",
             backend.target_address
@@ -231,26 +262,29 @@ async fn connect_to_http_proxy_backend(
         let backend_host = backend.target_address.ip().to_string();
         let domain = ServerName::try_from(backend_host)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-        let tls = client_tls::connect_using_tls_auth(socket, domain, state).await?;
-        Box::new(tls)
+
+        let alpn_protocols = match inbound_protocol {
+            InboundHttpProtocol::Http1 => vec![ALPN_HTTP1_1.to_vec(), ALPN_H2.to_vec()],
+            InboundHttpProtocol::Http2 => vec![ALPN_H2.to_vec(), ALPN_HTTP1_1.to_vec()],
+        };
+        let tls = client_tls::connect_using_tls_auth(socket, domain, state, alpn_protocols).await?;
+
+        let use_http2 = match tls {
+            tokio_rustls::TlsStream::Client(ref client) => client
+                .get_ref()
+                .1
+                .alpn_protocol()
+                .map(|p| p.as_ref() as &[u8] == ALPN_H2)
+                .unwrap_or(false),
+            _ => false,
+        };
+
+        (Box::new(tls), use_http2)
     } else {
-        Box::new(socket)
+        (Box::new(socket), false)
     };
 
     let io = TokioIo::new(stream);
-
-    let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
-        .handshake(io)
-        .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
-    // We must await the connection (and enable upgrades)
-    // https://docs.rs/hyper/latest/hyper/client/conn/http1/struct.Builder.html#method.handshake
-    tokio::spawn(async move {
-        if let Err(e) = conn.with_upgrades().await {
-            warn!("Cannot HTTP CONNECT to upstream: {}", e);
-        }
-    });
 
     // The following points are important for choosing the current implementation of the CONNECT:
     // 1. hyper has optimized the way it parses headers:
@@ -264,26 +298,69 @@ async fn connect_to_http_proxy_backend(
         .body(Empty::<Bytes>::new())
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
 
-    let mut response = sender
-        .send_request(request)
-        .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    if use_http2 {
+        let (mut sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+            .handshake(io)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        tokio::spawn(async move {
+            if let Err(e) = conn.await {
+                warn!("Cannot HTTP CONNECT to upstream: {}", e);
+            }
+        });
 
-    if !response.status().is_success() {
-        return Err(io::Error::new(
-            io::ErrorKind::ConnectionRefused,
-            format!(
-                "HTTP proxy CONNECT failed with status {}",
-                response.status()
-            ),
-        ));
+        let mut response = sender
+            .send_request(request)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        if !response.status().is_success() {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!(
+                    "HTTP proxy CONNECT failed with status {}",
+                    response.status()
+                ),
+            ));
+        }
+
+        let upgraded = hyper::upgrade::on(&mut response)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        Ok(Box::new(TokioIo::new(upgraded)) as OutboundStream)
+    } else {
+        let (mut sender, conn) = hyper::client::conn::http1::Builder::new()
+            .handshake(io)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        // We must await the connection (and enable upgrades)
+        // https://docs.rs/hyper/latest/hyper/client/conn/http1/struct.Builder.html#method.handshake
+        tokio::spawn(async move {
+            if let Err(e) = conn.with_upgrades().await {
+                warn!("Cannot HTTP CONNECT to upstream: {}", e);
+            }
+        });
+
+        let mut response = sender
+            .send_request(request)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        if !response.status().is_success() {
+            return Err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                format!(
+                    "HTTP proxy CONNECT failed with status {}",
+                    response.status()
+                ),
+            ));
+        }
+
+        let upgraded = hyper::upgrade::on(&mut response)
+            .await
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        Ok(Box::new(TokioIo::new(upgraded)))
     }
-
-    let upgraded = hyper::upgrade::on(&mut response)
-        .await
-        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
-
-    let stream: OutboundStream = Box::new(TokioIo::new(upgraded));
-
-    Ok(stream)
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -22,7 +22,7 @@ mod socks5;
 
 use context::InboundStream;
 use http_connect::{serve_http1_connect, serve_http2_connect};
-use protocol_detect::{DetectedProtocol, detect_protocol, detect_tls};
+use protocol_detect::{DetectedProtocol, detect_protocol, detect_tls, ALPN_H2, ALPN_HTTP1_1};
 use socks5::serve_socks5;
 
 #[derive(Debug, Error)]
@@ -104,7 +104,7 @@ async fn build_tls_acceptor(
                 server_certs.cert_chain.clone(),
                 server_certs.private_key.clone_key(),
             )?;
-            config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+            config.alpn_protocols = vec![ALPN_H2.to_vec(), ALPN_HTTP1_1.to_vec()];
             Ok(Some(TlsAcceptor::from(Arc::new(config))))
         } else {
             Ok(None)

--- a/src/proxy/protocol_detect.rs
+++ b/src/proxy/protocol_detect.rs
@@ -4,6 +4,9 @@ use crate::proxy::context::InboundStream;
 
 const H2_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 
+pub const ALPN_H2: &[u8] = b"h2";
+pub const ALPN_HTTP1_1: &[u8] = b"http/1.1";
+
 pub enum DetectedProtocol {
     Socks5,
     Http1,
@@ -42,10 +45,10 @@ pub async fn detect_protocol(
                 let (_io, session) = server_stream.get_ref();
                 if let Some(alpn) = session.alpn_protocol() {
                     let alpn: &[u8] = alpn.as_ref();
-                    if alpn == b"h2" {
+                    if alpn == ALPN_H2 {
                         return Ok((DetectedProtocol::Http2, socket));
                     }
-                    if alpn == b"http/1.1" {
+                    if alpn == ALPN_HTTP1_1 {
                         return Ok((DetectedProtocol::Http1, socket));
                     }
                 }

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -28,7 +28,8 @@ pub async fn connect_to_backend(
         let target_socket = TcpStream::connect(backend.target_address).await?;
         let stream = crate::proxy::client_tls::connect_using_tls_auth(target_socket,
             domain,
-            state.clone()
+            state.clone(),
+            vec![],
         ).await?;
 
         Ok(OutboundSock5Stream::Tls(Socks5Stream::use_stream(stream, None, config).await?))


### PR DESCRIPTION
This PR handle HTTP/2 CONNECT (https://github.com/cloud-gouv/portail/issues/4)


TODO:
- [x] tests
- [x] http2 client (connect to an upstream proxy)