### PR TITLE
fix: missing TLS ServerName

### DIFF
--- a/benches/acl.rs
+++ b/benches/acl.rs
@@ -186,6 +186,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let backend_setting = BackendSettings {
         identity_aware: false,
         target_address: "1.1.1.1:443".parse().unwrap(),
+        tls_server_name: None,
     };
 
     for id in 1..=5 {

--- a/benches/acl.rs
+++ b/benches/acl.rs
@@ -4,7 +4,7 @@ use portail::{
         ACLRules, EvaluationContext, OwnedEvaluationContext, ast::ConcreteOperand, ast_to_hir,
         parser::parse_into_ast,
     },
-    config::BackendSettings,
+    config::{BackendSettings, ServerName},
 };
 use rand::RngExt;
 use std::{collections::HashMap, hint::black_box};
@@ -183,10 +183,11 @@ fn eval(host: &str, rules: ACLRules) {
 fn criterion_benchmark(c: &mut Criterion) {
     let sizes = ["small", "medium", "large"];
     let mut backends = HashMap::new();
+    let target_address = "1.1.1.1:443".parse().unwrap();
     let backend_setting = BackendSettings {
         identity_aware: false,
-        target_address: "1.1.1.1:443".parse().unwrap(),
-        tls_server_name: None,
+        target_address,
+        tls_server_name: ServerName::from(target_address.ip()),
     };
 
     for id in 1..=5 {

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -5,6 +5,7 @@ tcp_nodelay = false
 [backends.par01a]
 target-address = "127.0.0.2:8000"
 identity-aware = true
+tls-server-name = "proxy.example.com"
 
 [backends.par01b]
 target-address = "127.0.0.2:8001"

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -560,6 +560,102 @@ in
     '';
   };
 
+  # curl -> portail -(TLS)-> portail (hop) -> corp-server
+  #
+  # Block any direct TCP from first portail to corp.
+  # This blocks the portail fallback path (direct connection).
+  #
+  portail-identity-aware-upstream =
+    let
+      upstreamId = "192.168.1.60";
+    in
+    pkgs.testers.nixosTest {
+      name = "portail-identity-aware-upstream";
+      nodes = {
+        corp-server = mkServiceNode { };
+
+        portail-hop = { nodes, ... }@args: {
+          imports = [
+            (mkPortailNode { address = upstreamId; } args)
+            {
+              services.portail.settings.listener = {
+                tls-privkey = certs.proxyCerts.${portailDomain}.key;
+                tls-chain = certs.proxyCerts.${portailDomain}.cert;
+              };
+            }
+          ];
+        };
+
+        node = { nodes, ... }@args: {
+          imports = [
+            (mkPortailNode { address = "192.168.1.100"; } args)
+            (
+              { nodes, ... }:
+              {
+                # Prevent any direct TCP from this host to corp.
+                # This blocks the portail fallback path.
+                # We use REJECT instead of DROP to reduce test latency.
+                networking.firewall.extraCommands = ''
+                  iptables -I OUTPUT -p tcp -d ${nodes.corp-server.networking.primaryIPAddress} -j REJECT --reject-with tcp-reset
+                '';
+
+                security.pki.certificates = [
+                  (builtins.readFile certs.proxyCerts.ca.cert)
+                  (builtins.readFile certs.workloadCerts.ca.cert)
+                ];
+
+                services.portail.settings = {
+                  default-backend = "default";
+                  backends.default = {
+                    target-address = "${nodes.portail-hop.networking.primaryIPAddress}:8080";
+                    identity-aware = true;
+                  };
+                  listener = {
+                    # Trust anchor for verifying the upstream (hop) TLS server certificate.
+                    cacert-file = certs.proxyCerts.ca.cert;
+                  };
+                };
+              }
+            )
+          ];
+        };
+      };
+
+      testScript = ''
+        import json
+
+        start_all()
+
+        node.wait_for_unit("multi-user.target")
+        node.wait_for_unit("portail.service")
+
+        portail_hop.wait_for_unit("multi-user.target")
+        portail_hop.wait_for_unit("portail.service")
+
+        corp_server.wait_for_unit("multi-user.target")
+        corp_server.wait_for_open_port(443)
+
+        node.wait_for_open_port(8080)
+        portail_hop.wait_for_open_port(8080)
+
+        # The direct route is blocked, so the proxy cannot fallback.
+        node.fail(
+          "curl --fail --max-time 5 https://hello.corp.example.com/"
+        )
+
+        # Test HTTP CONNECT curl -> portail -(TLS)-> portail (hop) -> corp-server
+        result = json.loads(node.succeed(
+          "curl --fail --max-time 5 --proxy http://127.0.0.1:8080 https://hello.corp.example.com"
+        ))
+        assert (
+          result['service'] == 'hello.corp'
+          and result['remote_addr'] == "${upstreamId}"
+          and result['tls']
+          and result['protocol'] == 'HTTP/2.0'
+        ), "Unexpected result from the web service: {}".format(json.dumps(result))
+      '';
+    };
+
   portail-backend-dynamic-switching = pkgs.testers.nixosTest {
     name = "portail-multiple-backends";
     nodes = {

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -567,7 +567,7 @@ in
   #
   portail-identity-aware-upstream =
     let
-      upstreamId = "192.168.1.60";
+      upstreamIp = "192.168.1.60";
     in
     pkgs.testers.nixosTest {
       name = "portail-identity-aware-upstream";
@@ -576,7 +576,7 @@ in
 
         portail-hop = { nodes, ... }@args: {
           imports = [
-            (mkPortailNode { address = upstreamId; } args)
+            (mkPortailNode { address = upstreamIp; } args)
             {
               services.portail.settings.listener = {
                 tls-privkey = certs.proxyCerts.${portailDomain}.key;
@@ -609,6 +609,7 @@ in
                   backends.default = {
                     target-address = "${nodes.portail-hop.networking.primaryIPAddress}:8080";
                     identity-aware = true;
+                    tls-server-name = portailDomain;
                   };
                   listener = {
                     # Trust anchor for verifying the upstream (hop) TLS server certificate.
@@ -649,7 +650,7 @@ in
         ))
         assert (
           result['service'] == 'hello.corp'
-          and result['remote_addr'] == "${upstreamId}"
+          and result['remote_addr'] == "${upstreamIp}"
           and result['tls']
           and result['protocol'] == 'HTTP/2.0'
         ), "Unexpected result from the web service: {}".format(json.dumps(result))

--- a/src/acl/evaluator.rs
+++ b/src/acl/evaluator.rs
@@ -496,15 +496,21 @@ mod tests {
     fn test_route_evaluation() {
         use crate::acl::hir::{ACLHir, RouteDefinition};
 
-        let backend1 = BackendSettings {
-            target_address: "1.1.1.1:443".parse().unwrap(),
-            identity_aware: false,
-            tls_server_name: None,
+        let backend1 = {
+            let target_address = "1.1.1.1:443".parse().unwrap();
+            BackendSettings {
+                target_address,
+                identity_aware: false,
+                tls_server_name: crate::config::ServerName::from(target_address.ip()),
+            }
         };
-        let backend2 = BackendSettings {
-            target_address: "1.1.1.2:443".parse().unwrap(),
-            identity_aware: false,
-            tls_server_name: None,
+        let backend2 = {
+            let target_address = "1.1.1.2:443".parse().unwrap();
+            BackendSettings {
+                target_address,
+                identity_aware: false,
+                tls_server_name: crate::config::ServerName::from(target_address.ip()),
+            }
         };
 
         let hir = ACLHir {

--- a/src/acl/evaluator.rs
+++ b/src/acl/evaluator.rs
@@ -499,10 +499,12 @@ mod tests {
         let backend1 = BackendSettings {
             target_address: "1.1.1.1:443".parse().unwrap(),
             identity_aware: false,
+            tls_server_name: None,
         };
         let backend2 = BackendSettings {
             target_address: "1.1.1.2:443".parse().unwrap(),
             identity_aware: false,
+            tls_server_name: None,
         };
 
         let hir = ACLHir {

--- a/src/acl/hir.rs
+++ b/src/acl/hir.rs
@@ -207,6 +207,7 @@ mod tests {
                 BackendSettings {
                     target_address: "1.1.1.1:443".parse().unwrap(),
                     identity_aware: false,
+                    tls_server_name: None,
                 },
             );
         }

--- a/src/acl/hir.rs
+++ b/src/acl/hir.rs
@@ -192,7 +192,7 @@ mod tests {
     use super::*;
     use crate::acl::Action;
     use crate::acl::ast;
-    use crate::config::BackendSettings;
+    use crate::config::{BackendSettings, ServerName};
     use insta::assert_debug_snapshot;
     use std::collections::HashMap;
 
@@ -202,12 +202,13 @@ mod tests {
         let mut backends = HashMap::new();
 
         for id in ids {
+            let target_address = "1.1.1.1:443".parse().unwrap();
             backends.insert(
                 id.to_string(),
                 BackendSettings {
-                    target_address: "1.1.1.1:443".parse().unwrap(),
+                    target_address,
                     identity_aware: false,
-                    tls_server_name: None,
+                    tls_server_name: ServerName::from(target_address.ip()),
                 },
             );
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,20 +5,69 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+pub use tokio_rustls::rustls::pki_types::ServerName;
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone)]
 pub struct BackendSettings {
     pub target_address: SocketAddr,
     /// Whether this backend requires a TLS connection with a client certificate.
-    #[serde(default)]
     pub identity_aware: bool,
     /// TLS server name for identity-aware outbound connections.
     ///
-    /// When unset, the IP address is used.
+    /// When omitted in config, the target address IP is used.
+    pub tls_server_name: ServerName<'static>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct BackendSettingsSerde {
+    target_address: SocketAddr,
     #[serde(default)]
-    pub tls_server_name: Option<String>,
+    identity_aware: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    tls_server_name: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for BackendSettings {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = BackendSettingsSerde::deserialize(deserializer)?;
+        let tls_server_name = match s.tls_server_name {
+            Some(str) => ServerName::try_from(str)
+                .map_err(|e| de::Error::custom(format!("invalid tls_server_name: {e:?}")))?,
+            None => ServerName::from(s.target_address.ip()),
+        };
+
+        Ok(BackendSettings {
+            target_address: s.target_address,
+            identity_aware: s.identity_aware,
+            tls_server_name,
+        })
+    }
+}
+
+impl Serialize for BackendSettings {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let tls_default = ServerName::from(self.target_address.ip());
+        let tls_server_name = if self.tls_server_name == tls_default {
+            None
+        } else {
+            Some(self.tls_server_name.to_str().into_owned())
+        };
+
+        BackendSettingsSerde {
+            target_address: self.target_address,
+            identity_aware: self.identity_aware,
+            tls_server_name,
+        }
+        .serialize(serializer)
+    }
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,11 @@ pub struct BackendSettings {
     /// Whether this backend requires a TLS connection with a client certificate.
     #[serde(default)]
     pub identity_aware: bool,
+    /// TLS server name for identity-aware outbound connections.
+    ///
+    /// When unset, the IP address is used.
+    #[serde(default)]
+    pub tls_server_name: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ pub struct BackendSettings {
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-struct BackendSettingsSerde {
+struct RawBackendSettings {
     target_address: SocketAddr,
     #[serde(default)]
     identity_aware: bool,
@@ -34,7 +34,7 @@ impl<'de> Deserialize<'de> for BackendSettings {
     where
         D: Deserializer<'de>,
     {
-        let s = BackendSettingsSerde::deserialize(deserializer)?;
+        let s = RawBackendSettings::deserialize(deserializer)?;
         let tls_server_name = match s.tls_server_name {
             Some(str) => ServerName::try_from(str)
                 .map_err(|e| de::Error::custom(format!("invalid tls_server_name: {e:?}")))?,
@@ -61,7 +61,7 @@ impl Serialize for BackendSettings {
             Some(self.tls_server_name.to_str().into_owned())
         };
 
-        BackendSettingsSerde {
+        RawBackendSettings {
             target_address: self.target_address,
             identity_aware: self.identity_aware,
             tls_server_name,

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -327,7 +327,11 @@ async fn connect_to_http_proxy_backend(
             "Backend is identity-aware, establishing a TLS connection to {}",
             backend.target_address
         );
-        let backend_host = backend.target_address.ip().to_string();
+        let backend_host = backend
+            .tls_server_name
+            .clone()
+            .unwrap_or_else(|| backend.target_address.ip().to_string());
+
         let domain = ServerName::try_from(backend_host)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
 

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::RwLock;
-use tokio_rustls::rustls::pki_types::ServerName;
 use tracing::{debug, error, info, warn};
 
 /// This is a workaround for the restriction `only auto traits can be used as additional traits in a trait object`
@@ -327,13 +326,7 @@ async fn connect_to_http_proxy_backend(
             "Backend is identity-aware, establishing a TLS connection to {}",
             backend.target_address
         );
-        let backend_host = backend
-            .tls_server_name
-            .clone()
-            .unwrap_or_else(|| backend.target_address.ip().to_string());
-
-        let domain = ServerName::try_from(backend_host)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let domain = backend.tls_server_name.clone();
 
         let alpn_protocols = match inbound_protocol {
             InboundHttpProtocol::Http1 => vec![ALPN_HTTP1_1.to_vec(), ALPN_H2.to_vec()],

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -1,4 +1,5 @@
 use std::{
+    io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
 };
@@ -37,8 +38,12 @@ pub async fn connect_to_backend(
 
     if backend.identity_aware {
         debug!("Backend is identity-aware, establishing a TLS connection to the backend first");
-        // TODO: remove the panic
-        let domain = ServerName::try_from(target_addr).unwrap();
+        let backend_host = backend
+            .tls_server_name
+            .clone()
+            .unwrap_or_else(|| backend.target_address.ip().to_string());
+        let domain = ServerName::try_from(backend_host)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
         let target_socket = TcpStream::connect(backend.target_address).await?;
         let stream = crate::proxy::client_tls::connect_using_tls_auth(
             target_socket,

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -1,5 +1,4 @@
 use std::{
-    io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::Arc,
 };
@@ -13,7 +12,7 @@ use tokio::{
     net::TcpStream,
     sync::RwLock,
 };
-use tokio_rustls::{TlsStream, rustls::pki_types::ServerName};
+use tokio_rustls::TlsStream;
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -38,12 +37,7 @@ pub async fn connect_to_backend(
 
     if backend.identity_aware {
         debug!("Backend is identity-aware, establishing a TLS connection to the backend first");
-        let backend_host = backend
-            .tls_server_name
-            .clone()
-            .unwrap_or_else(|| backend.target_address.ip().to_string());
-        let domain = ServerName::try_from(backend_host)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+        let domain = backend.tls_server_name.clone();
         let target_socket = TcpStream::connect(backend.target_address).await?;
         let stream = crate::proxy::client_tls::connect_using_tls_auth(
             target_socket,


### PR DESCRIPTION
Fixes #51 

First commit e522d8332b45329c75c8cccce7c9482cdb57da3b shows the bug with a failing test:
`portail::proxy::http_connect: Backend 192.168.1.3:8080 failed for HTTP CONNECT: invalid peer certificate: certificate not valid for name "192.168.1.3"; certificate is only valid for DnsName("portail.corp.example.com"), trying next`

