### PR TITLE
rpc: introduce ListBackends

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -789,6 +789,12 @@ in
       assert cur_backend == "<none>", f"Expected no default backend set, but got: {cur_backend}"
       assert rpc("set-default-backend", "alpha", user="alice").get("success", False), "Unable to set the default backend as trusted user alice"
 
+      # Check we can list backends and verify the response.
+      backends = rpc("list-backends")
+      assert any(b.get('current', False) for b in backends), "Expected at least one backend to be active"
+      assert [b for b in backends if b.get('current', False)][0].get('id') == "alpha", "Expected active backend to be alpha"
+      assert len(backends) == 2, "Expected two backends (alpha and beta)"
+
       # Test SOCKS5 curl -> portail -> portail alpha -> corp-server
       result = json.loads(node.succeed(
         "curl --fail --socks5 http://127.0.0.1:8080 http://hello.corp.example.com"

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,9 @@ enum RpcCommands {
 
     /// Unset the default backend via RPC.
     UnsetDefaultBackend,
+
+    /// List all available backends via RPC.
+    ListBackends,
 }
 
 #[derive(Subcommand)]
@@ -180,6 +183,31 @@ async fn main() -> Result<()> {
                             }),
                         )
                         .context("While writing JSON")?;
+                    }
+                }
+
+                RpcCommands::ListBackends => {
+                    let mut connection = zlink::unix::connect(&rpc_socket).await.context(
+                        format!("Opening the RPC socket at path '{}'", rpc_socket.display()),
+                    )?;
+                    let backends = connection
+                        .list_backends()
+                        .await
+                        .context("During Varlink low-level communications. Are you using same versions of Portail on both sides?")?
+                        .context("Failed to set default backend")?.backends;
+
+                    if !json {
+                        println!("List of backends:");
+                        for backend in backends {
+                            if backend.current {
+                                println!("\t{} (active)", backend.id);
+                            } else {
+                                println!("\t{}", backend.id);
+                            }
+                        }
+                    } else {
+                        serde_json::to_writer(std::io::stdout(), &serde_json::json!(backends))
+                            .context("While writing JSON")?;
                     }
                 }
             }

--- a/src/rpc/fr.gouv.portail.control.varlink
+++ b/src/rpc/fr.gouv.portail.control.varlink
@@ -2,6 +2,12 @@ interface fr.gouv.portail.Control
 
 method SetDefaultBackend(backend_id: ?string)
 method GetCurrentBackend() -> (backend_id: string)
+method ListBackends() -> (backends: []BackendInfo)
+
+type BackendInfo (
+    id: string,
+    current: bool
+)
 
 # A backend was passed to a method but was not found
 error BackendNotFound (provided_backend: string, available_backends: []string)

--- a/src/rpc/fr_gouv_portail_control.rs
+++ b/src/rpc/fr_gouv_portail_control.rs
@@ -56,10 +56,24 @@ pub trait Control {
     async fn get_current_backend(
         &mut self,
     ) -> zlink::Result<Result<GetCurrentBackendOutput, ControlError>>;
+    async fn list_backends(&mut self) -> zlink::Result<Result<ListBackendsOutput, ControlError>>;
 }
 
 /// Output parameters for the GetCurrentBackend method.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GetCurrentBackendOutput {
     pub backend_id: String,
+}
+
+/// Type BackendInfo.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BackendInfo {
+    pub id: String,
+    pub current: bool,
+}
+
+/// Output parameters for the ListBackends method.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ListBackendsOutput {
+    pub backends: Vec<BackendInfo>,
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,6 +1,8 @@
 use crate::{
     config::Settings,
-    rpc::fr_gouv_portail_control::{ControlError, GetCurrentBackendOutput},
+    rpc::fr_gouv_portail_control::{
+        BackendInfo, ControlError, GetCurrentBackendOutput, ListBackendsOutput,
+    },
     state::State,
 };
 use std::{collections::HashSet, ffi::CStr, sync::Arc};
@@ -143,6 +145,26 @@ where
                 .default_backend
                 .clone()
                 .unwrap_or("<none>".to_string()),
+        }
+    }
+
+    async fn list_backends(&mut self) -> ListBackendsOutput {
+        let cur_backend = self.state.read().await.default_backend.clone();
+        ListBackendsOutput {
+            backends: self
+                .settings
+                .backends
+                .keys()
+                .map(|backend_id|
+                    // TODO: expose more information about the backend but safely!
+                    BackendInfo {
+                        id: backend_id.to_owned(),
+                        current: cur_backend
+                            .as_ref()
+                            .map(|cur_backend_id| *cur_backend_id == *backend_id)
+                            .unwrap_or(false),
+                    })
+                .collect(),
         }
     }
 }


### PR DESCRIPTION
This allows a tray icon to show a menu to switch to a different backend.

The return is optimized to show which backend is effectively the current if any.