### PR TITLE
proxy/acl: introduce `route.local`

### DIFF
--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -173,6 +173,48 @@ async fn handle_http_request(
 
     // TODO: how much header information should we render available?
 
+    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&acl.hir) {
+        Ok(routes) => routes,
+        Err(failure) => {
+            let mut resp = Response::new(empty_body());
+            warn!(
+                "Failed to evaluate a request: {} (Context: {:#?})",
+                failure, ctx
+            );
+            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            return Ok(resp);
+        }
+    };
+
+    if !recommended_routes.is_empty() {
+        backends.append(&mut recommended_routes);
+    }
+
+    if backends.is_empty()
+        && let Some(ref backend_id) = state.read().await.default_backend
+    {
+        let backend = settings
+            .backends
+            .get(backend_id)
+            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from settings"));
+
+        backends.push(backend);
+    }
+
+    backends.reverse();
+
+    if backends.is_empty() {
+        ctx.acl_ctx.insert(
+            "route.local",
+            crate::acl::ast::ConcreteOperand::Boolean(true),
+        );
+    } else {
+        ctx.acl_ctx.insert(
+            "route.local",
+            crate::acl::ast::ConcreteOperand::Boolean(false),
+        );
+    }
+
     let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
         Ok(assessment) => assessment,
         Err(failure) => {
@@ -205,36 +247,6 @@ async fn handle_http_request(
 
         _ => {}
     }
-
-    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&acl.hir) {
-        Ok(routes) => routes,
-        Err(failure) => {
-            let mut resp = Response::new(empty_body());
-            warn!(
-                "Failed to evaluate a request: {} (Context: {:#?})",
-                failure, ctx
-            );
-            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-            return Ok(resp);
-        }
-    };
-
-    if !recommended_routes.is_empty() {
-        backends.append(&mut recommended_routes);
-    }
-
-    if backends.is_empty()
-        && let Some(ref backend_id) = state.read().await.default_backend
-    {
-        let backend = settings
-            .backends
-            .get(backend_id)
-            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from settings"));
-
-        backends.push(backend);
-    }
-
-    backends.reverse();
 
     let mut stream: Option<OutboundStream> = None;
     for backend in backends {

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -143,8 +143,50 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     }
 
     let mut backends: Vec<&BackendSettings> = Vec::with_capacity(1);
-    // We evaluate first whether we are allowed then we evaluate routes.
     let acl = &state.read().await.acl_rules;
+
+    // We evaluate first the routes as it can influence the ACL in case of a local exit.
+    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&acl.hir) {
+        Ok(routes) => routes,
+        Err(failure) => {
+            proto.reply_error(&ReplyError::GeneralFailure).await?;
+            warn!(
+                "Failed to evaluate routes for a request: {} (Context: {:#?})",
+                failure, ctx
+            );
+            return Ok(());
+        }
+    };
+
+    if !recommended_routes.is_empty() {
+        backends.append(&mut recommended_routes);
+    }
+
+    if backends.is_empty()
+        && let Some(ref backend_id) = state.read().await.default_backend
+    {
+        let backend = opts
+            .backends
+            .get(backend_id)
+            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from settings"));
+
+        backends.push(backend);
+    }
+
+    backends.reverse();
+
+    if backends.is_empty() {
+        ctx.acl_ctx.insert(
+            "route.local",
+            crate::acl::ast::ConcreteOperand::Boolean(true),
+        );
+    } else {
+        ctx.acl_ctx.insert(
+            "route.local",
+            crate::acl::ast::ConcreteOperand::Boolean(false),
+        );
+    }
+
     let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
         Ok(assessment) => assessment,
         Err(failure) => {
@@ -182,35 +224,6 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
 
         _ => {}
     }
-
-    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&acl.hir) {
-        Ok(routes) => routes,
-        Err(failure) => {
-            proto.reply_error(&ReplyError::GeneralFailure).await?;
-            warn!(
-                "Failed to evaluate routes for a request: {} (Context: {:#?})",
-                failure, ctx
-            );
-            return Ok(());
-        }
-    };
-
-    if !recommended_routes.is_empty() {
-        backends.append(&mut recommended_routes);
-    }
-
-    if backends.is_empty()
-        && let Some(ref backend_id) = state.read().await.default_backend
-    {
-        let backend = opts
-            .backends
-            .get(backend_id)
-            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from settings"));
-
-        backends.push(backend);
-    }
-
-    backends.reverse();
 
     // Either, we route to another backend or we do the SOCKS5 proxying ourselves.
     while let Some(backend) = backends.pop() {


### PR DESCRIPTION
This helps to know whether we are going to exit via our local system and not via another chained proxy.

Use cases: when the local system with a local Portail has no exit towards an infrastructure proxy, it can work in a limited fashion with a very strict ACL.

~~TODO: tests.~~ Skipped because it's too simple.