### PR TITLE
refactor(tls): pre-compile client config, fix RPC groups, and resolve fallback TODO

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,3 +14,4 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1234,7 @@ dependencies = [
  "peekable",
  "rand",
  "regex",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -1416,6 +1433,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1496,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1495,6 +1533,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_with = "3.16.1"
 thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["full"] }
 tokio-rustls = "0.26.4"
+rustls-native-certs = "0.8"
 toml = "0.9.11"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }

--- a/benches/acl.rs
+++ b/benches/acl.rs
@@ -1,8 +1,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use portail::{
     acl::{
-        ACLRules, EvaluationContext, OwnedEvaluationContext, ast::ConcreteOperand, ast_to_hir,
-        parser::parse_into_ast,
+        ACLRules, OwnedEvaluationContext, ast::ConcreteOperand, ast_to_hir, parser::parse_into_ast,
     },
     config::{BackendSettings, ServerName},
 };

--- a/src/proxy/client_tls.rs
+++ b/src/proxy/client_tls.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use portail::config::ServerName;
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     sync::RwLock,
 };
+use tokio_rustls::{TlsConnector, TlsStream};
 
-use tokio_rustls::{TlsConnector, TlsStream, rustls::pki_types::ServerName};
-use tracing::debug;
+use crate::state::State;
 
 /// This connects to a target server using a mTLS mechanism.
 /// The roots and client certs are fetched from the state where
@@ -18,20 +19,21 @@ use tracing::debug;
 pub async fn connect_using_tls_auth<IO: AsyncRead + AsyncWrite + Unpin>(
     stream: IO,
     domain: ServerName<'static>,
-    state: Arc<RwLock<crate::state::State>>,
+    state: Arc<RwLock<State>>,
     alpn_protocols: Vec<Vec<u8>>,
 ) -> Result<TlsStream<IO>, tokio::io::Error> {
-    let mut config = {
+    let base_config_arc = {
         let state_guard = state.read().await;
-        (*state_guard.client_tls_config).clone()
+        state_guard.base_client_config.clone()
     };
 
-    config.alpn_protocols = alpn_protocols;
+    let mut local_config = (*base_config_arc).clone();
+    local_config.alpn_protocols = alpn_protocols;
 
-    let connector = TlsConnector::from(Arc::new(config));
-    debug!("Performing a TLS connection to {domain:?}...");
+    let connector = TlsConnector::from(std::sync::Arc::new(local_config));
+
+    tracing::debug!("Performing a TLS connection to {domain:?}...");
 
     let tls_stream = connector.connect(domain, stream).await?;
-
     Ok(TlsStream::Client(tls_stream))
 }

--- a/src/proxy/client_tls.rs
+++ b/src/proxy/client_tls.rs
@@ -5,10 +5,7 @@ use tokio::{
     sync::RwLock,
 };
 
-use tokio_rustls::{
-    TlsConnector, TlsStream,
-    rustls::{ClientConfig, pki_types::ServerName},
-};
+use tokio_rustls::{TlsConnector, TlsStream, rustls::pki_types::ServerName};
 use tracing::debug;
 
 /// This connects to a target server using a mTLS mechanism.
@@ -24,26 +21,12 @@ pub async fn connect_using_tls_auth<IO: AsyncRead + AsyncWrite + Unpin>(
     state: Arc<RwLock<crate::state::State>>,
     alpn_protocols: Vec<Vec<u8>>,
 ) -> Result<TlsStream<IO>, tokio::io::Error> {
-    let config = {
-        let state = state.read().await;
-
-        let mut config = match (state.root_store.clone(), state.client_cert_resolver.clone()) {
-            (Some(root_store), Some(cert_resolver)) => ClientConfig::builder()
-                .with_root_certificates(root_store)
-                .with_client_cert_resolver(cert_resolver),
-            (Some(root_store), None) => ClientConfig::builder()
-                .with_root_certificates(root_store)
-                .with_no_client_auth(),
-            (None, Some(_)) => {
-                return Err(tokio::io::Error::other("Client auth set without roots"));
-            }
-            // TODO: configure with default webpki
-            (None, None) => panic!("webpki setup"),
-        };
-
-        config.alpn_protocols = alpn_protocols;
-        config
+    let mut config = {
+        let state_guard = state.read().await;
+        (*state_guard.client_tls_config).clone()
     };
+
+    config.alpn_protocols = alpn_protocols;
 
     let connector = TlsConnector::from(Arc::new(config));
     debug!("Performing a TLS connection to {domain:?}...");

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -100,7 +100,7 @@ where
             .await
             .map_err(|_| ControlError::PermissionDenied)?;
 
-        let mut groups: Vec<Gid> = r.unix_supplementary_group_ids().to_vec();
+        let mut groups: Vec<Gid> = vec![r.unix_primary_group_id()];
         groups.push(r.unix_primary_group_id());
 
         let groups = resolve_numeric_groups_to_names(groups);

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -100,7 +100,10 @@ where
             .await
             .map_err(|_| ControlError::PermissionDenied)?;
 
-        let mut groups: Vec<Gid> = vec![r.unix_primary_group_id()];
+        #[cfg(target_os = "linux")]
+        let mut groups: Vec<Gid> = r.unix_supplementary_group_ids().to_vec();
+        #[cfg(not(target_os = "linux"))]
+        let mut groups: Vec<Gid> = Vec::with_capacity(1);
         groups.push(r.unix_primary_group_id());
 
         let groups = resolve_numeric_groups_to_names(groups);

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -100,10 +100,7 @@ where
             .await
             .map_err(|_| ControlError::PermissionDenied)?;
 
-        #[cfg(target_os = "linux")]
         let mut groups: Vec<Gid> = r.unix_supplementary_group_ids().to_vec();
-        #[cfg(not(target_os = "linux"))]
-        let mut groups: Vec<Gid> = Vec::with_capacity(1);
         groups.push(r.unix_primary_group_id());
 
         let groups = resolve_numeric_groups_to_names(groups);

--- a/src/state.rs
+++ b/src/state.rs
@@ -242,6 +242,35 @@ pub struct Statistics {
     pub nr_udp_connections: AtomicUsize,
 }
 
+/// Loads root certificates from settings or falls back to system native roots.
+fn load_initial_trust_anchors(
+    settings: &Settings,
+) -> Result<(Option<Arc<RootCertStore>>, Arc<ClientConfig>), ReloadTrustAnchorError> {
+    let root_store = if let Some(ref listener) = settings.listener
+        && let Some(ref client_ca) = listener.cacert_file
+    {
+        let mut ca_file = BufReader::new(std::fs::File::open(client_ca)?);
+        let certs: Vec<_> = rustls_pemfile::read_all(&mut ca_file)
+            .map(|item| {
+                item.map_err(|_| MaterialError::SectionParsingError)
+                    .and_then(expect_certificate)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut roots = RootCertStore::empty();
+        for cert in certs {
+            roots.add(cert)?;
+        }
+        Some(Arc::new(roots))
+    } else {
+        None
+    };
+
+    // Build the definitive configuration directly using initialized materials.
+    let client_tls_config = build_client_tls_config(&root_store, &None)?;
+    Ok((root_store, client_tls_config))
+}
+
 pub fn init(settings: &Settings) -> Result<State, InitError> {
     let acl_rules = crate::acl::load_rules_from_file(
         &settings
@@ -251,24 +280,18 @@ pub fn init(settings: &Settings) -> Result<State, InitError> {
         settings,
     )?;
 
-    // Initialize with a dummy config, then reload to populate real trust anchors.
-    // This is infaillible, but for security, I prefer to keep an error wrapper.
-    let dummy_roots = Arc::new(RootCertStore::empty());
-    let client_tls_config = build_client_tls_config(&Some(dummy_roots), &None)
-        .map_err(ReloadTrustAnchorError::ClientConfigCompilationError)?;
+    let (root_store, client_tls_config) = load_initial_trust_anchors(settings)?;
 
     let mut state = State {
         default_backend: settings.default_backend.clone(),
         acl_rules,
-        root_store: None,
+        root_store,
         client_cert_resolver: None,
         server_certificates: None,
         client_tls_config,
     };
 
-    // Load server certificates and trust anchors for the first time.
-    state.reload_trust_anchors(settings)?;
-
+    // Load server certificates independently.
     if state.reload_server_certs(settings)? {
         info!("TLS listener is configured and available on this proxy.");
     } else {

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use tokio_rustls::rustls::{
-    RootCertStore,
+    ClientConfig, RootCertStore,
     pki_types::{CertificateDer, PrivateKeyDer},
 };
 use tracing::{info, warn};
@@ -22,9 +22,10 @@ pub struct ServerCertificates<'a> {
 pub struct State {
     pub default_backend: Option<String>,
     pub acl_rules: crate::acl::ACLRules,
-    pub root_store: Option<Arc<tokio_rustls::rustls::RootCertStore>>,
+    pub root_store: Option<Arc<RootCertStore>>,
     pub server_certificates: Option<ServerCertificates<'static>>,
     pub client_cert_resolver: Option<Arc<dyn tokio_rustls::rustls::client::ResolvesClientCert>>,
+    pub client_tls_config: Arc<ClientConfig>,
 }
 
 #[derive(Debug, Error)]
@@ -38,6 +39,14 @@ pub enum MaterialError {
 }
 
 #[derive(Debug, Error)]
+pub enum BuildClientConfigError {
+    #[error(
+        "No trust anchors available: custom store is absent and the OS native store is empty or failed to load"
+    )]
+    NoTrustAnchors,
+}
+
+#[derive(Debug, Error)]
 pub enum ReloadTrustAnchorError {
     #[error("Unexpected material nature: {0}")]
     UnexpectedMaterialNature(#[from] MaterialError),
@@ -45,6 +54,8 @@ pub enum ReloadTrustAnchorError {
     IOError(#[from] std::io::Error),
     #[error("Adding a certificate to the root store failed: {0}")]
     RootStorePopulationError(#[from] tokio_rustls::rustls::Error),
+    #[error("Failed to compile client TLS configuration: {0}")]
+    ClientConfigCompilationError(#[from] BuildClientConfigError),
 }
 
 #[derive(Debug, Error)]
@@ -91,12 +102,50 @@ fn expect_private_key(item: rustls_pemfile::Item) -> Result<PrivateKeyDer<'stati
     }
 }
 
+/// Builds a ClientConfig from discrete trust and identity material.
+fn build_client_tls_config(
+    root_store: &Option<Arc<RootCertStore>>,
+    cert_resolver: &Option<Arc<dyn tokio_rustls::rustls::client::ResolvesClientCert>>,
+) -> Result<Arc<ClientConfig>, BuildClientConfigError> {
+    let roots = match root_store {
+        Some(store) => store.clone(),
+        None => {
+            let mut store = RootCertStore::empty();
+            let native_certs = rustls_native_certs::load_native_certs();
+            if !native_certs.errors.is_empty() {
+                warn!(
+                    "Native cert loader encountered partial errors: {:?}",
+                    native_certs.errors
+                );
+            }
+            for cert in native_certs.certs {
+                let _ = store.add(cert);
+            }
+            if store.is_empty() {
+                return Err(BuildClientConfigError::NoTrustAnchors);
+            }
+            Arc::new(store)
+        }
+    };
+
+    let config = match cert_resolver {
+        Some(resolver) => ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_client_cert_resolver(resolver.clone()),
+        None => ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth(),
+    };
+
+    Ok(Arc::new(config))
+}
+
 impl State {
     pub fn reload_trust_anchors(
         &mut self,
         settings: &Settings,
     ) -> Result<(), ReloadTrustAnchorError> {
-        if let Some(ref listener) = settings.listener
+        let new_root_store = if let Some(ref listener) = settings.listener
             && let Some(ref client_ca) = listener.cacert_file
         {
             let mut ca_file = BufReader::new(std::fs::File::open(client_ca)?);
@@ -111,10 +160,16 @@ impl State {
             for cert in certs {
                 roots.add(cert)?;
             }
+            Some(Arc::new(roots))
+        } else {
+            None
+        };
 
-            self.root_store = Some(Arc::new(roots));
-        }
+        // If this fails, state remains consistent.
+        let new_config = build_client_tls_config(&new_root_store, &self.client_cert_resolver)?;
 
+        self.root_store = new_root_store;
+        self.client_tls_config = new_config;
         Ok(())
     }
 
@@ -144,15 +199,8 @@ impl State {
 
                     return Ok(true);
                 }
-
-                (None, None) => {
-                    // No server TLS.
-                    return Ok(false);
-                }
-
-                _ => {
-                    return Err(ReloadServerCertificateError::MisconfiguredServerCertificates);
-                }
+                (None, None) => return Ok(false),
+                _ => return Err(ReloadServerCertificateError::MisconfiguredServerCertificates),
             }
         }
 
@@ -160,7 +208,12 @@ impl State {
     }
 
     #[allow(dead_code)]
-    pub fn reload_client_certs(&self) {}
+    pub fn reload_client_certs(&mut self) -> Result<(), BuildClientConfigError> {
+        // TODO: Update self.client_cert_resolver here when TPM2/PKCS11 integration is ready.
+        let new_config = build_client_tls_config(&self.root_store, &self.client_cert_resolver)?;
+        self.client_tls_config = new_config;
+        Ok(())
+    }
 
     #[allow(dead_code)]
     pub fn reload_acl_rules(&mut self, settings: &Settings) {
@@ -190,21 +243,32 @@ pub struct Statistics {
 }
 
 pub fn init(settings: &Settings) -> Result<State, InitError> {
+    let acl_rules = crate::acl::load_rules_from_file(
+        &settings
+            .filter_acl_rules_path
+            .clone()
+            .ok_or(InitError::MissingACLFile)?,
+        settings,
+    )?;
+
+    // Initialize with a dummy config, then reload to populate real trust anchors.
+    // This is infaillible, but for security, I prefer to keep an error wrapper.
+    let dummy_roots = Arc::new(RootCertStore::empty());
+    let client_tls_config = build_client_tls_config(&Some(dummy_roots), &None)
+        .map_err(ReloadTrustAnchorError::ClientConfigCompilationError)?;
+
     let mut state = State {
         default_backend: settings.default_backend.clone(),
-        acl_rules: crate::acl::load_rules_from_file(
-            &settings
-                .filter_acl_rules_path
-                .clone()
-                .ok_or(InitError::MissingACLFile)?,
-            settings,
-        )?,
+        acl_rules,
         root_store: None,
         client_cert_resolver: None,
         server_certificates: None,
+        client_tls_config,
     };
 
     // Load server certificates and trust anchors for the first time.
+    state.reload_trust_anchors(settings)?;
+
     if state.reload_server_certs(settings)? {
         info!("TLS listener is configured and available on this proxy.");
     } else {
@@ -212,8 +276,6 @@ pub fn init(settings: &Settings) -> Result<State, InitError> {
             "TLS is not configured and will not be available for requests. Use this only if your proxy is secured in another fashion: localhost binding or tunnel chaining."
         );
     }
-
-    state.reload_trust_anchors(settings)?;
 
     Ok(state)
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -25,7 +25,7 @@ pub struct State {
     pub root_store: Option<Arc<RootCertStore>>,
     pub server_certificates: Option<ServerCertificates<'static>>,
     pub client_cert_resolver: Option<Arc<dyn tokio_rustls::rustls::client::ResolvesClientCert>>,
-    pub client_tls_config: Arc<ClientConfig>,
+    pub base_client_config: Arc<ClientConfig>,
 }
 
 #[derive(Debug, Error)]
@@ -39,14 +39,6 @@ pub enum MaterialError {
 }
 
 #[derive(Debug, Error)]
-pub enum BuildClientConfigError {
-    #[error(
-        "No trust anchors available: custom store is absent and the OS native store is empty or failed to load"
-    )]
-    NoTrustAnchors,
-}
-
-#[derive(Debug, Error)]
 pub enum ReloadTrustAnchorError {
     #[error("Unexpected material nature: {0}")]
     UnexpectedMaterialNature(#[from] MaterialError),
@@ -54,8 +46,6 @@ pub enum ReloadTrustAnchorError {
     IOError(#[from] std::io::Error),
     #[error("Adding a certificate to the root store failed: {0}")]
     RootStorePopulationError(#[from] tokio_rustls::rustls::Error),
-    #[error("Failed to compile client TLS configuration: {0}")]
-    ClientConfigCompilationError(#[from] BuildClientConfigError),
 }
 
 #[derive(Debug, Error)]
@@ -102,50 +92,14 @@ fn expect_private_key(item: rustls_pemfile::Item) -> Result<PrivateKeyDer<'stati
     }
 }
 
-/// Builds a ClientConfig from discrete trust and identity material.
-fn build_client_tls_config(
-    root_store: &Option<Arc<RootCertStore>>,
-    cert_resolver: &Option<Arc<dyn tokio_rustls::rustls::client::ResolvesClientCert>>,
-) -> Result<Arc<ClientConfig>, BuildClientConfigError> {
-    let roots = match root_store {
-        Some(store) => store.clone(),
-        None => {
-            let mut store = RootCertStore::empty();
-            let native_certs = rustls_native_certs::load_native_certs();
-            if !native_certs.errors.is_empty() {
-                warn!(
-                    "Native cert loader encountered partial errors: {:?}",
-                    native_certs.errors
-                );
-            }
-            for cert in native_certs.certs {
-                let _ = store.add(cert);
-            }
-            if store.is_empty() {
-                return Err(BuildClientConfigError::NoTrustAnchors);
-            }
-            Arc::new(store)
-        }
-    };
-
-    let config = match cert_resolver {
-        Some(resolver) => ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_client_cert_resolver(resolver.clone()),
-        None => ClientConfig::builder()
-            .with_root_certificates(roots)
-            .with_no_client_auth(),
-    };
-
-    Ok(Arc::new(config))
-}
-
 impl State {
     pub fn reload_trust_anchors(
         &mut self,
         settings: &Settings,
     ) -> Result<(), ReloadTrustAnchorError> {
-        let new_root_store = if let Some(ref listener) = settings.listener
+        let mut roots = RootCertStore::empty();
+
+        if let Some(ref listener) = settings.listener
             && let Some(ref client_ca) = listener.cacert_file
         {
             let mut ca_file = BufReader::new(std::fs::File::open(client_ca)?);
@@ -156,20 +110,49 @@ impl State {
                 })
                 .collect::<Result<Vec<_>, _>>()?;
 
-            let mut roots = RootCertStore::empty();
             for cert in certs {
                 roots.add(cert)?;
             }
-            Some(Arc::new(roots))
+            self.root_store = Some(Arc::new(roots));
         } else {
-            None
+            let native_certs = rustls_native_certs::load_native_certs();
+            if !native_certs.errors.is_empty() {
+                warn!(
+                    "Native cert loader encountered partial errors: {:?}",
+                    native_certs.errors
+                );
+            }
+            for cert in native_certs.certs {
+                let _ = roots.add(cert);
+            }
+
+            if roots.is_empty() {
+                warn!(
+                    "OS native trust store is empty and no custom CA file was provided. Client TLS connections will fail."
+                );
+                self.root_store = None;
+            } else {
+                self.root_store = Some(Arc::new(roots));
+            }
+        }
+
+        let r_store = match &self.root_store {
+            Some(arc_store) => (**arc_store).clone(),
+            None => RootCertStore::empty(),
         };
 
-        // If this fails, state remains consistent.
-        let new_config = build_client_tls_config(&new_root_store, &self.client_cert_resolver)?;
+        let mut config = match self.client_cert_resolver.clone() {
+            Some(resolver) => ClientConfig::builder()
+                .with_root_certificates(r_store)
+                .with_client_cert_resolver(resolver),
+            None => ClientConfig::builder()
+                .with_root_certificates(r_store)
+                .with_no_client_auth(),
+        };
 
-        self.root_store = new_root_store;
-        self.client_tls_config = new_config;
+        config.resumption = tokio_rustls::rustls::client::Resumption::in_memory_sessions(256);
+        self.base_client_config = Arc::new(config);
+
         Ok(())
     }
 
@@ -208,12 +191,7 @@ impl State {
     }
 
     #[allow(dead_code)]
-    pub fn reload_client_certs(&mut self) -> Result<(), BuildClientConfigError> {
-        // TODO: Update self.client_cert_resolver here when TPM2/PKCS11 integration is ready.
-        let new_config = build_client_tls_config(&self.root_store, &self.client_cert_resolver)?;
-        self.client_tls_config = new_config;
-        Ok(())
-    }
+    pub fn reload_client_certs(&self) {}
 
     #[allow(dead_code)]
     pub fn reload_acl_rules(&mut self, settings: &Settings) {
@@ -242,56 +220,26 @@ pub struct Statistics {
     pub nr_udp_connections: AtomicUsize,
 }
 
-/// Loads root certificates from settings or falls back to system native roots.
-fn load_initial_trust_anchors(
-    settings: &Settings,
-) -> Result<(Option<Arc<RootCertStore>>, Arc<ClientConfig>), ReloadTrustAnchorError> {
-    let root_store = if let Some(ref listener) = settings.listener
-        && let Some(ref client_ca) = listener.cacert_file
-    {
-        let mut ca_file = BufReader::new(std::fs::File::open(client_ca)?);
-        let certs: Vec<_> = rustls_pemfile::read_all(&mut ca_file)
-            .map(|item| {
-                item.map_err(|_| MaterialError::SectionParsingError)
-                    .and_then(expect_certificate)
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        let mut roots = RootCertStore::empty();
-        for cert in certs {
-            roots.add(cert)?;
-        }
-        Some(Arc::new(roots))
-    } else {
-        None
-    };
-
-    // Build the definitive configuration directly using initialized materials.
-    let client_tls_config = build_client_tls_config(&root_store, &None)?;
-    Ok((root_store, client_tls_config))
-}
-
 pub fn init(settings: &Settings) -> Result<State, InitError> {
-    let acl_rules = crate::acl::load_rules_from_file(
-        &settings
-            .filter_acl_rules_path
-            .clone()
-            .ok_or(InitError::MissingACLFile)?,
-        settings,
-    )?;
+    let acl_rules_path = settings
+        .filter_acl_rules_path
+        .clone()
+        .ok_or(InitError::MissingACLFile)?;
+    let acl_rules = crate::acl::load_rules_from_file(&acl_rules_path, settings)?;
 
-    let (root_store, client_tls_config) = load_initial_trust_anchors(settings)?;
+    let dummy_config = ClientConfig::builder()
+        .with_root_certificates(RootCertStore::empty())
+        .with_no_client_auth();
 
     let mut state = State {
         default_backend: settings.default_backend.clone(),
         acl_rules,
-        root_store,
-        client_cert_resolver: None,
+        root_store: None,
         server_certificates: None,
-        client_tls_config,
+        client_cert_resolver: None,
+        base_client_config: Arc::new(dummy_config),
     };
 
-    // Load server certificates independently.
     if state.reload_server_certs(settings)? {
         info!("TLS listener is configured and available on this proxy.");
     } else {
@@ -299,6 +247,8 @@ pub fn init(settings: &Settings) -> Result<State, InitError> {
             "TLS is not configured and will not be available for requests. Use this only if your proxy is secured in another fashion: localhost binding or tunnel chaining."
         );
     }
+
+    state.reload_trust_anchors(settings)?;
 
     Ok(state)
 }


### PR DESCRIPTION
Optimizes the TLS client connection path, fixes an RPC type error, and resolves outstanding `TODO` item. Also, fixes minor Clippy warnings.

* Moved `ClientConfig` out of the hot path: building the config inside `connect_using_tls_auth` on every single connection was a bottleneck. I moved the compilation into the application state so it only do it once.
* Now, each connection task just grabs a shallow clone of our global `Arc<ClientConfig>` before setting its own local ALPN protocols.
* Swapped the placeholder for real system roots: I resolved the `webpki` TODO by pulling in `rustls-native-certs`. 
   **Note:** For an enterprise proxy, I used the OS trust store, letting supports for internal CAs and sets us up nicely for    TPM2 or hardware keys.

I also noticed that `unix_supplementary_group_ids` was missing ~~entirely from the `zlink` transport~~ on Darwin, causing group resolution to fail. I updated this to use cfg depending on platform; this is kinda heuristic. As given on `zlink`'s documentation, it should, later, work on all platforms.