### PR TITLE
Support dynamic backends

### DIFF
--- a/benches/acl.rs
+++ b/benches/acl.rs
@@ -4,7 +4,7 @@ use portail::{
         ACLRules, EvaluationContext, OwnedEvaluationContext, ast::ConcreteOperand, ast_to_hir,
         parser::parse_into_ast,
     },
-    config::{BackendSettings, ServerName},
+    config::{BackendSettings, KnownBackend, ServerName},
 };
 use rand::RngExt;
 use std::{collections::HashMap, hint::black_box};
@@ -184,11 +184,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     let sizes = ["small", "medium", "large"];
     let mut backends = HashMap::new();
     let target_address = "1.1.1.1:443".parse().unwrap();
-    let backend_setting = BackendSettings {
+    let backend_setting = BackendSettings::KnownBackend(KnownBackend {
         identity_aware: false,
         target_address,
         tls_server_name: ServerName::from(target_address.ip()),
-    };
+    });
 
     for id in 1..=5 {
         backends.insert(format!("exit{}", id), backend_setting.clone());

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -684,6 +684,11 @@ in
 
         users.groups.portailers = {};
         users.groups.heloise = {};
+        users.groups.portail-admins = {};
+        users.users.portail-admin = {
+          isNormalUser = true;
+          extraGroups = [ "portail-admins" ];
+        };
         users.users.alice = {
           isNormalUser = true;
           # supplementary group, not main group.
@@ -704,7 +709,10 @@ in
 
           settings = {
             default-backend = "alpha";
-            rpc.trusted-groups = [ "heloise" "portailers" ];
+            rpc = {
+              admin-groups = [ "portail-admins" ];
+              trusted-groups = [ "heloise" "portailers" ];
+            };
             backends = {
               alpha = {
                 target-address =
@@ -712,6 +720,9 @@ in
               };
 
               beta.target-address = "${nodes.microsocks-beta.networking.primaryIPAddress}:8080";
+
+              # Target address is not known in advance.
+              gamma.dynamic = true;
             };
           };
 
@@ -767,6 +778,11 @@ in
           else:
             raise e
 
+      def read_backend(backend_id: str) -> dict[str, str]:
+        backends = rpc("list-backends")
+        backend = [b for b in backends if b.get('id') == backend_id][0]
+        return backend.get("spec")
+
       # Verify that RPC permissions are set correctly.
       # Everyone can read, including the attacker.
       # Only trusted groups can change backends.
@@ -793,7 +809,14 @@ in
       backends = rpc("list-backends")
       assert any(b.get('current', False) for b in backends), "Expected at least one backend to be active"
       assert [b for b in backends if b.get('current', False)][0].get('id') == "alpha", "Expected active backend to be alpha"
-      assert len(backends) == 2, "Expected two backends (alpha and beta)"
+      assert len(backends) == 3, "Expected two backends (alpha, beta and gamma)"
+
+      # Dynamic backend RPC tests.
+      for user in ("alice", "heloise", "attacker"):
+        assert rpc("update-dynamic-backend", "gamma", "--target-address", "10.0.0.1:443", user=user, fail=True) is None, "Unexpectedly was able to update the dynamic backend gamma even though we are not an admin user"
+
+      assert rpc("update-dynamic-backend", "gamma", "--target-address", "10.0.0.1:443", user="portail-admin").get("success", False), "Unable to update the dynamic backend as portail-admin"
+      assert read_backend("gamma")["target_address"] == "10.0.0.1:443", "Target address change after dynamic update was not effective"
 
       # Test SOCKS5 curl -> portail -> portail alpha -> corp-server
       result = json.loads(node.succeed(

--- a/src/acl/evaluator.rs
+++ b/src/acl/evaluator.rs
@@ -161,8 +161,9 @@ impl<'s> EvaluationContext<'s> {
     /// failover.
     pub fn evaluate_routes(
         &self,
+        backends: &HashMap<String, BackendSettings>,
         rules: &'s hir::ACLHir,
-    ) -> Result<Vec<&'s BackendSettings>, InterpretationError<'s>> {
+    ) -> Result<Vec<BackendSettings>, InterpretationError<'s>> {
         let mut routes = Vec::new();
         // At this point, we can assume that the set of rules are parsed and validated.
         // So we can assume each policy block contain the relevant amount of information and we
@@ -181,7 +182,12 @@ impl<'s> EvaluationContext<'s> {
             // We fulfill when, let's look at the recommended routes.
             routes.reserve(entry.r#use.len());
             for reco in &entry.r#use {
-                routes.push(reco);
+                routes.push(
+                    backends
+                        .get(reco)
+                        .expect("Invariant violation: backend {} has disappeared from the state")
+                        .to_owned(),
+                );
             }
         }
 
@@ -248,6 +254,8 @@ impl<'s> EvaluationContext<'s> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use crate::{
         acl::{Action, OwnedEvaluationContext},
         config::{BackendSettings, KnownBackend},
@@ -517,14 +525,19 @@ mod tests {
             routes: vec![RouteDefinition {
                 when: None,
                 name: "route_to_cf".to_string(),
-                r#use: vec![backend1, backend2],
+                r#use: vec!["backend1".to_string(), "backend2".to_string()],
             }],
             policies: vec![],
         };
 
+        let specs = HashMap::from([
+            ("backend1".to_string(), backend1),
+            ("backend2".to_string(), backend2),
+        ]);
+
         let ctx = OwnedEvaluationContext::empty();
         let ctx = ctx.fork();
-        let routes = ctx.evaluate_routes(&hir).unwrap();
+        let routes = ctx.evaluate_routes(&specs, &hir).unwrap();
         assert_eq!(routes.len(), 2);
     }
 }

--- a/src/acl/evaluator.rs
+++ b/src/acl/evaluator.rs
@@ -250,7 +250,7 @@ impl<'s> EvaluationContext<'s> {
 mod tests {
     use crate::{
         acl::{Action, OwnedEvaluationContext},
-        config::BackendSettings,
+        config::{BackendSettings, KnownBackend},
     };
 
     #[cfg(test)]
@@ -498,19 +498,19 @@ mod tests {
 
         let backend1 = {
             let target_address = "1.1.1.1:443".parse().unwrap();
-            BackendSettings {
+            BackendSettings::KnownBackend(KnownBackend {
                 target_address,
                 identity_aware: false,
                 tls_server_name: crate::config::ServerName::from(target_address.ip()),
-            }
+            })
         };
         let backend2 = {
             let target_address = "1.1.1.2:443".parse().unwrap();
-            BackendSettings {
+            BackendSettings::KnownBackend(KnownBackend {
                 target_address,
                 identity_aware: false,
                 tls_server_name: crate::config::ServerName::from(target_address.ip()),
-            }
+            })
         };
 
         let hir = ACLHir {

--- a/src/acl/hir.rs
+++ b/src/acl/hir.rs
@@ -192,6 +192,7 @@ mod tests {
     use super::*;
     use crate::acl::Action;
     use crate::acl::ast;
+    use crate::config::KnownBackend;
     use crate::config::{BackendSettings, ServerName};
     use insta::assert_debug_snapshot;
     use std::collections::HashMap;
@@ -205,11 +206,11 @@ mod tests {
             let target_address = "1.1.1.1:443".parse().unwrap();
             backends.insert(
                 id.to_string(),
-                BackendSettings {
+                BackendSettings::KnownBackend(KnownBackend {
                     target_address,
                     identity_aware: false,
                     tls_server_name: ServerName::from(target_address.ip()),
-                },
+                }),
             );
         }
 

--- a/src/acl/hir.rs
+++ b/src/acl/hir.rs
@@ -11,7 +11,8 @@ use crate::config::BackendSettings;
 pub struct RouteDefinition {
     pub name: String,
     pub when: Option<ast::Expression>,
-    pub r#use: Vec<BackendSettings>,
+    /// List of backend IDs
+    pub r#use: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -49,7 +50,7 @@ fn route_to_hir(
     available_backends: &HashMap<String, BackendSettings>,
 ) -> Result<RouteDefinition, TransformationError> {
     let mut when: Option<ast::Expression> = None;
-    let mut r#use: Vec<BackendSettings> = Vec::new();
+    let mut r#use: Vec<String> = Vec::new();
     let mut missing_backends: Vec<&str> = Vec::new();
 
     for attribute in route.attributes {
@@ -72,8 +73,8 @@ fn route_to_hir(
             }
 
             for backend_key in backends {
-                if let Some(backend) = available_backends.get(backend_key) {
-                    r#use.push(backend.to_owned());
+                if available_backends.contains_key(backend_key) {
+                    r#use.push(backend_key.to_owned());
                 } else {
                     missing_backends.push(backend_key);
                 }
@@ -190,7 +191,6 @@ pub fn ast_to_hir<'s>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::acl::Action;
     use crate::acl::ast;
     use crate::config::KnownBackend;
     use crate::config::{BackendSettings, ServerName};

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 pub use tokio_rustls::rustls::pki_types::ServerName;
 
 #[derive(Debug, Clone)]
-pub struct BackendSettings {
+pub struct KnownBackend {
     pub target_address: SocketAddr,
     /// Whether this backend requires a TLS connection with a client certificate.
     pub identity_aware: bool,
@@ -19,10 +19,20 @@ pub struct BackendSettings {
     pub tls_server_name: ServerName<'static>,
 }
 
+#[derive(Debug, Clone)]
+pub enum BackendSettings {
+    /// This is a backend (dynamic or not) which has been resolved to a backend.
+    KnownBackend(KnownBackend),
+    /// This is a dynamic backend for which we do not know the target address yet.
+    UnresolvedBackend,
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 struct RawBackendSettings {
-    target_address: SocketAddr,
+    target_address: Option<SocketAddr>,
+    #[serde(default)]
+    dynamic: bool,
     #[serde(default)]
     identity_aware: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -35,17 +45,30 @@ impl<'de> Deserialize<'de> for BackendSettings {
         D: Deserializer<'de>,
     {
         let s = RawBackendSettings::deserialize(deserializer)?;
-        let tls_server_name = match s.tls_server_name {
-            Some(str) => ServerName::try_from(str)
-                .map_err(|e| de::Error::custom(format!("invalid tls_server_name: {e:?}")))?,
-            None => ServerName::from(s.target_address.ip()),
-        };
 
-        Ok(BackendSettings {
-            target_address: s.target_address,
-            identity_aware: s.identity_aware,
-            tls_server_name,
-        })
+        if !s.dynamic && s.target_address.is_none() {
+            return Err(de::Error::custom(
+                "Target address cannot be omitted if the backend is not dynamic",
+            ));
+        }
+
+        match s.target_address {
+            Some(tgt_address) => {
+                let tls_server_name = match s.tls_server_name {
+                    Some(str) => ServerName::try_from(str).map_err(|e| {
+                        de::Error::custom(format!("invalid tls_server_name: {e:?}"))
+                    })?,
+                    None => ServerName::from(tgt_address.ip()),
+                };
+
+                Ok(BackendSettings::KnownBackend(KnownBackend {
+                    target_address: tgt_address,
+                    identity_aware: s.identity_aware,
+                    tls_server_name,
+                }))
+            }
+            None => Ok(BackendSettings::UnresolvedBackend),
+        }
     }
 }
 
@@ -54,17 +77,32 @@ impl Serialize for BackendSettings {
     where
         S: Serializer,
     {
-        let tls_default = ServerName::from(self.target_address.ip());
-        let tls_server_name = if self.tls_server_name == tls_default {
-            None
-        } else {
-            Some(self.tls_server_name.to_str().into_owned())
-        };
+        match self {
+            Self::UnresolvedBackend => RawBackendSettings {
+                target_address: None,
+                identity_aware: false,
+                dynamic: true,
+                tls_server_name: None,
+            },
+            Self::KnownBackend(KnownBackend {
+                target_address,
+                identity_aware,
+                tls_server_name,
+            }) => {
+                let tls_default = ServerName::from(target_address.ip());
+                let tls_server_name = if *tls_server_name == tls_default {
+                    None
+                } else {
+                    Some(tls_server_name.to_str().into_owned())
+                };
 
-        RawBackendSettings {
-            target_address: self.target_address,
-            identity_aware: self.identity_aware,
-            tls_server_name,
+                RawBackendSettings {
+                    target_address: Some(*target_address),
+                    identity_aware: *identity_aware,
+                    dynamic: false,
+                    tls_server_name,
+                }
+            }
         }
         .serialize(serializer)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,6 +131,11 @@ pub struct EscapeSettings {
 #[derive(Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct RPCSettings {
+    /// Administrative groups are allowed to call admin RPCs such as UpdateDynamicBackend.
+    /// They can disable the proxy functionality or bypass it by redirecting the
+    /// dynamic backend to an attacker-controlled target.
+    #[serde(default)]
+    pub admin_groups: Vec<String>,
     /// Trusted groups are allowed to call write RPC such as SetDefaultBackend or Reload.
     /// They cannot disable the proxy functionality nonetheless.
     #[serde(default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ async fn main() -> Result<()> {
                         .set_default_backend(None)
                         .await
                         .context("During Varlink low-level communications. Are you using same versions of Portail on both sides?")?
-                        .context("Failed to set default backend")?;
+                        .context("Failed to unset default backend")?;
 
                     if !json {
                         println!("Default backend unset successfully.");
@@ -204,7 +204,7 @@ async fn main() -> Result<()> {
                         .list_backends()
                         .await
                         .context("During Varlink low-level communications. Are you using same versions of Portail on both sides?")?
-                        .context("Failed to set default backend")?.backends;
+                        .context("Failed to list backends")?.backends;
 
                     if !json {
                         println!("List of backends:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use std::net::SocketAddr;
 use std::os::fd::FromRawFd;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
@@ -7,7 +8,7 @@ use tracing::{error, level_filters::LevelFilter};
 use tracing::{info, warn};
 use tracing_subscriber::EnvFilter;
 
-use crate::rpc::fr_gouv_portail_control::GetCurrentBackendOutput;
+use crate::rpc::fr_gouv_portail_control::{DynamicBackendSpec, GetCurrentBackendOutput};
 use crate::systemd::sd_notify_ready;
 
 mod acl;
@@ -51,6 +52,15 @@ enum RpcCommands {
 
     /// List all available backends via RPC.
     ListBackends,
+
+    /// Update a dynamic backend via RPC
+    UpdateDynamicBackend {
+        /// Identifier of the backend in the settings
+        backend_id: String,
+
+        #[arg(long)]
+        target_address: SocketAddr,
+    },
 }
 
 #[derive(Subcommand)]
@@ -208,6 +218,34 @@ async fn main() -> Result<()> {
                     } else {
                         serde_json::to_writer(std::io::stdout(), &serde_json::json!(backends))
                             .context("While writing JSON")?;
+                    }
+                }
+
+                RpcCommands::UpdateDynamicBackend {
+                    backend_id,
+                    target_address,
+                } => {
+                    let mut connection = zlink::unix::connect(&rpc_socket).await.context(
+                        format!("Opening the RPC socket at path '{}'", rpc_socket.display()),
+                    )?;
+                    connection
+                        .update_dynamic_backend(&backend_id, DynamicBackendSpec {
+                            target_address: format!("{}", target_address),
+                            identity_aware: false,
+                            tls_server_name: None
+                        })
+                        .await
+                        .context("During Varlink low-level communications. Are you using same versions of Portail on both sides?")?
+                        .context("Failed to update the dynamic backend")?;
+
+                    if !json {
+                        println!("Backend updated.");
+                    } else {
+                        serde_json::to_writer(
+                            std::io::stdout(),
+                            &serde_json::json!({"success": true}),
+                        )
+                        .context("While writing JSON")?;
                     }
                 }
             }

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -1,3 +1,4 @@
+use crate::config::KnownBackend;
 use crate::proxy::context::InitialRequestContext;
 use crate::proxy::protocol_detect::{ALPN_H2, ALPN_HTTP1_1};
 use crate::{
@@ -250,27 +251,40 @@ async fn handle_http_request(
 
     let mut stream: Option<OutboundStream> = None;
     for backend in backends {
-        debug!(
-            "Backend {} selected for HTTP CONNECT to {}",
-            backend.target_address, final_address
-        );
-        match connect_to_http_proxy_backend(
-            backend,
-            &final_address,
-            state.clone(),
-            &inbound_protocol,
-        )
-        .await
-        {
-            Ok(upstream) => {
-                stream = Some(upstream);
-                break;
-            }
-            Err(err) => {
-                debug!(
-                    "Backend {} failed for HTTP CONNECT: {}, trying next",
-                    backend.target_address, err
+        match backend {
+            BackendSettings::UnresolvedBackend => {
+                // TODO: keep the IDs to print them here.
+                tracing::error!(
+                    "An unresolved backend was selected during HTTP CONNECT routing. This should not happen, rejecting the request."
                 );
+                let mut resp = Response::new(empty_body());
+                *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                return Ok(resp);
+            }
+            BackendSettings::KnownBackend(backend) => {
+                debug!(
+                    "Backend {} selected for HTTP CONNECT to {}",
+                    backend.target_address, final_address
+                );
+                match connect_to_http_proxy_backend(
+                    backend,
+                    &final_address,
+                    state.clone(),
+                    &inbound_protocol,
+                )
+                .await
+                {
+                    Ok(upstream) => {
+                        stream = Some(upstream);
+                        break;
+                    }
+                    Err(err) => {
+                        debug!(
+                            "Backend {} failed for HTTP CONNECT: {}, trying next",
+                            backend.target_address, err
+                        );
+                    }
+                }
             }
         }
     }
@@ -327,7 +341,7 @@ fn empty_body() -> BoxBody<Bytes, hyper::Error> {
 ///
 /// When upstream is plain TCP, HTTP/1.1 is used.
 async fn connect_to_http_proxy_backend(
-    backend: &BackendSettings,
+    backend: &KnownBackend,
     final_address: &str,
     state: Arc<RwLock<State>>,
     inbound_protocol: &InboundHttpProtocol,

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -104,7 +104,7 @@ pub async fn serve_http2_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
 async fn handle_http_request(
     req: Request<Incoming>,
     ctx: InitialRequestContext,
-    settings: Arc<Settings>,
+    _settings: Arc<Settings>,
     state: Arc<RwLock<State>>,
     inbound_protocol: InboundHttpProtocol,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
@@ -135,7 +135,8 @@ async fn handle_http_request(
 
     let target_address = target_authority.to_string();
     let mut final_address = target_address.clone();
-    let mut backends: Vec<&BackendSettings> = Vec::with_capacity(1);
+    let mut backends: Vec<BackendSettings> = Vec::with_capacity(1);
+    let backend_specs = &state.read().await.backends;
     // We evaluate first whether we are allowed then we evaluate routes.
     let acl = &state.read().await.acl_rules;
 
@@ -174,7 +175,7 @@ async fn handle_http_request(
 
     // TODO: how much header information should we render available?
 
-    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&acl.hir) {
+    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(backend_specs, &acl.hir) {
         Ok(routes) => routes,
         Err(failure) => {
             let mut resp = Response::new(empty_body());
@@ -194,10 +195,13 @@ async fn handle_http_request(
     if backends.is_empty()
         && let Some(ref backend_id) = state.read().await.default_backend
     {
-        let backend = settings
+        let backend = state
+            .read()
+            .await
             .backends
             .get(backend_id)
-            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from settings"));
+            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from state"))
+            .to_owned();
 
         backends.push(backend);
     }
@@ -267,7 +271,7 @@ async fn handle_http_request(
                     backend.target_address, final_address
                 );
                 match connect_to_http_proxy_backend(
-                    backend,
+                    &backend,
                     &final_address,
                     state.clone(),
                     &inbound_protocol,

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -142,11 +142,12 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         );
     }
 
-    let mut backends: Vec<&BackendSettings> = Vec::with_capacity(1);
+    let mut backends: Vec<BackendSettings> = Vec::with_capacity(1);
     let acl = &state.read().await.acl_rules;
+    let backend_specs = &state.read().await.backends;
 
     // We evaluate first the routes as it can influence the ACL in case of a local exit.
-    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&acl.hir) {
+    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(backend_specs, &acl.hir) {
         Ok(routes) => routes,
         Err(failure) => {
             proto.reply_error(&ReplyError::GeneralFailure).await?;
@@ -165,10 +166,13 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     if backends.is_empty()
         && let Some(ref backend_id) = state.read().await.default_backend
     {
-        let backend = opts
+        let backend = state
+            .read()
+            .await
             .backends
             .get(backend_id)
-            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from settings"));
+            .unwrap_or_else(|| panic!("BUG: default backend {backend_id} went away from state"))
+            .to_owned();
 
         backends.push(backend);
     }
@@ -242,7 +246,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                     &backend.target_address
                 );
 
-                match connect_to_backend(backend, &final_addr, state.clone()).await {
+                match connect_to_backend(&backend, &final_addr, state.clone()).await {
                     Ok(stream) => {
                         route_to_backend(stream, proto).await?;
                         return Ok(());

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -16,7 +16,7 @@ use tokio_rustls::TlsStream;
 use tracing::{debug, info, warn};
 
 use crate::{
-    config::{BackendSettings, Settings},
+    config::{BackendSettings, KnownBackend, Settings},
     proxy::context::{InitialRequestContext, TargetContext},
     state::State,
 };
@@ -28,7 +28,7 @@ pub enum OutboundSock5Stream {
 }
 
 pub async fn connect_to_backend(
-    backend: &BackendSettings,
+    backend: &KnownBackend,
     final_address: &TargetAddr,
     state: Arc<RwLock<State>>, // TODO: better error type
 ) -> Result<OutboundSock5Stream, SocksError> {
@@ -227,23 +227,35 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
 
     // Either, we route to another backend or we do the SOCKS5 proxying ourselves.
     while let Some(backend) = backends.pop() {
-        debug!(
-            "Backend {} selected for routing the connection",
-            &backend.target_address
-        );
-
-        match connect_to_backend(backend, &final_addr, state.clone()).await {
-            Ok(stream) => {
-                route_to_backend(stream, proto).await?;
+        match backend {
+            BackendSettings::UnresolvedBackend => {
+                // TODO: keep the IDs to print them here.
+                tracing::error!(
+                    "An unresolved backend was selected during SOCKS5 routing. This should not happen, rejecting the request."
+                );
+                proto.reply_error(&ReplyError::GeneralFailure).await?;
                 return Ok(());
             }
-
-            Err(err) => {
+            BackendSettings::KnownBackend(backend) => {
                 debug!(
-                    "Backend {} failed to route the request: {err}, trying the next one",
+                    "Backend {} selected for routing the connection",
                     &backend.target_address
                 );
-                continue;
+
+                match connect_to_backend(backend, &final_addr, state.clone()).await {
+                    Ok(stream) => {
+                        route_to_backend(stream, proto).await?;
+                        return Ok(());
+                    }
+
+                    Err(err) => {
+                        debug!(
+                            "Backend {} failed to route the request: {err}, trying the next one",
+                            &backend.target_address
+                        );
+                        continue;
+                    }
+                }
             }
         }
     }

--- a/src/rpc/fr.gouv.portail.control.varlink
+++ b/src/rpc/fr.gouv.portail.control.varlink
@@ -1,15 +1,26 @@
 interface fr.gouv.portail.Control
 
-method SetDefaultBackend(backend_id: ?string)
+method SetDefaultBackend(backend_id: ?string) -> ()
 method GetCurrentBackend() -> (backend_id: string)
-method ListBackends() -> (backends: []BackendInfo)
+method ListBackends() -> (backends: []BackendListItem)
+method UpdateDynamicBackend(backend_id: string, backend_spec: DynamicBackendSpec) -> ()
 
-type BackendInfo (
+type DynamicBackendSpec (
+  target_address: string,
+  identity_aware: bool,
+  tls_server_name: ?string
+)
+
+type BackendListItem (
     id: string,
     current: bool
 )
 
 # A backend was passed to a method but was not found
 error BackendNotFound (provided_backend: string, available_backends: []string)
+# Backend has invalid values (target address, TLS server names or something else.)
+error InvalidBackend (reason: string)
+# This backend is immutable and cannot be changed at runtime
+error ImmutableBackend ()
 # Client is not allowed to call this method.
 error PermissionDenied ()

--- a/src/rpc/fr.gouv.portail.control.varlink
+++ b/src/rpc/fr.gouv.portail.control.varlink
@@ -11,9 +11,17 @@ type DynamicBackendSpec (
   tls_server_name: ?string
 )
 
+type KnownBackendSpec (
+  target_address: string,
+  identity_aware: bool,
+  tls_server_name: string
+)
+
 type BackendListItem (
     id: string,
-    current: bool
+    current: bool,
+    dynamic: bool,
+    spec: ?KnownBackendSpec
 )
 
 # A backend was passed to a method but was not found

--- a/src/rpc/fr_gouv_portail_control.rs
+++ b/src/rpc/fr_gouv_portail_control.rs
@@ -4,8 +4,16 @@
 //! It was adapted for our needs.
 
 use serde::{Deserialize, Serialize};
-use std::{error::Error, fmt::Display};
+use std::{
+    error::Error,
+    fmt::Display,
+    net::{AddrParseError, SocketAddr},
+};
+use thiserror::Error;
+use tokio_rustls::rustls::pki_types::InvalidDnsNameError;
 use zlink::{ReplyError, proxy};
+
+use crate::config::KnownBackend;
 
 #[derive(Debug, Clone, PartialEq, ReplyError, zlink::introspect::ReplyError)]
 #[zlink(interface = "fr.gouv.portail.Control")]
@@ -14,6 +22,12 @@ pub enum ControlError {
         provided_backend: String,
         available_backends: Vec<String>,
     },
+    /// Backend has invalid values (target address, TLS server names or something else.)
+    InvalidBackend {
+        reason: String,
+    },
+    /// This backend is not dynamic and cannot be changed
+    ImmutableBackend,
     PermissionDenied,
 }
 
@@ -38,6 +52,14 @@ impl Display for ControlError {
             Self::PermissionDenied => {
                 f.write_str("Permission was denied, are you in the trusted group?")?
             }
+
+            Self::ImmutableBackend => {
+                f.write_str("Backend is not marked as dynamic and cannot be changed.")?
+            }
+
+            Self::InvalidBackend { reason } => {
+                f.write_fmt(format_args!("Backend passed had invalid data: {}", reason))?
+            }
         }
 
         Ok(())
@@ -57,6 +79,58 @@ pub trait Control {
         &mut self,
     ) -> zlink::Result<Result<GetCurrentBackendOutput, ControlError>>;
     async fn list_backends(&mut self) -> zlink::Result<Result<ListBackendsOutput, ControlError>>;
+    async fn update_dynamic_backend(
+        &mut self,
+        backend_id: &str,
+        backend_spec: DynamicBackendSpec,
+    ) -> zlink::Result<Result<(), ControlError>>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, zlink::introspect::Type)]
+pub struct DynamicBackendSpec {
+    pub target_address: String,
+    pub identity_aware: bool,
+    pub tls_server_name: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum DynamicBackendResolutionError {
+    #[error("Invalid target address: {0}")]
+    InvalidTargetAddress(#[from] AddrParseError),
+    #[error("Invalid TLS server name: {0}")]
+    InvalidServerName(#[from] InvalidDnsNameError),
+}
+
+impl TryFrom<DynamicBackendSpec> for KnownBackend {
+    type Error = DynamicBackendResolutionError;
+
+    fn try_from(value: DynamicBackendSpec) -> Result<Self, Self::Error> {
+        let tgt_address: SocketAddr = value.target_address.parse()?;
+        let ip = tgt_address.ip();
+        Ok(Self {
+            target_address: tgt_address,
+            identity_aware: value.identity_aware,
+            tls_server_name: match value.tls_server_name {
+                Some(str) => str.try_into()?,
+                None => ip.into(),
+            },
+        })
+    }
+}
+
+impl From<DynamicBackendResolutionError> for ControlError {
+    fn from(value: DynamicBackendResolutionError) -> Self {
+        match value {
+            DynamicBackendResolutionError::InvalidTargetAddress(err) => {
+                ControlError::InvalidBackend {
+                    reason: format!("Invalid target address: {}", err),
+                }
+            }
+            DynamicBackendResolutionError::InvalidServerName(err) => ControlError::InvalidBackend {
+                reason: format!("Invalid TLS server name: {}", err),
+            },
+        }
+    }
 }
 
 /// Output parameters for the GetCurrentBackend method.
@@ -65,9 +139,8 @@ pub struct GetCurrentBackendOutput {
     pub backend_id: String,
 }
 
-/// Type BackendInfo.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, zlink::introspect::Type)]
-pub struct BackendInfo {
+pub struct BackendListItem {
     pub id: String,
     pub current: bool,
 }
@@ -75,5 +148,5 @@ pub struct BackendInfo {
 /// Output parameters for the ListBackends method.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, zlink::introspect::Type)]
 pub struct ListBackendsOutput {
-    pub backends: Vec<BackendInfo>,
+    pub backends: Vec<BackendListItem>,
 }

--- a/src/rpc/fr_gouv_portail_control.rs
+++ b/src/rpc/fr_gouv_portail_control.rs
@@ -139,10 +139,31 @@ pub struct GetCurrentBackendOutput {
     pub backend_id: String,
 }
 
+/// A known backend specification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, zlink::introspect::Type)]
+pub struct KnownBackendSpec {
+    pub target_address: String,
+    pub identity_aware: bool,
+    pub tls_server_name: String,
+}
+
+impl From<KnownBackend> for KnownBackendSpec {
+    fn from(value: KnownBackend) -> Self {
+        Self {
+            target_address: format!("{}", value.target_address),
+            identity_aware: value.identity_aware,
+            tls_server_name: value.tls_server_name.to_str().into_owned(),
+        }
+    }
+}
+
+/// Returned as part of ListBackends method.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, zlink::introspect::Type)]
 pub struct BackendListItem {
     pub id: String,
     pub current: bool,
+    pub dynamic: bool,
+    pub spec: Option<KnownBackendSpec>,
 }
 
 /// Output parameters for the ListBackends method.

--- a/src/rpc/fr_gouv_portail_control.rs
+++ b/src/rpc/fr_gouv_portail_control.rs
@@ -50,7 +50,7 @@ impl Display for ControlError {
             }
 
             Self::PermissionDenied => {
-                f.write_str("Permission was denied, are you in the trusted group?")?
+                f.write_str("Permission was denied, are you in the authorized group?")?
             }
 
             Self::ImmutableBackend => {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,7 +1,8 @@
 use crate::{
-    config::Settings,
+    config::{BackendSettings, KnownBackend, Settings},
     rpc::fr_gouv_portail_control::{
-        BackendInfo, ControlError, GetCurrentBackendOutput, ListBackendsOutput,
+        BackendListItem, ControlError, DynamicBackendSpec, GetCurrentBackendOutput,
+        ListBackendsOutput,
     },
     state::State,
 };
@@ -10,7 +11,7 @@ use tokio::{net::UnixListener, sync::RwLock};
 use tracing::info;
 use zlink::{
     Server,
-    connection::{Gid, socket::FetchPeerCredentials},
+    connection::{Gid, Socket, socket::FetchPeerCredentials},
     service,
     unix::Listener,
 };
@@ -80,13 +81,56 @@ impl Control {
     }
 }
 
-/// FIXME: `env!()` cannot be used in the proc-macro below alas: https://github.com/z-galaxy/zlink/issues/237
+impl Control {
+    async fn check_authorization<S, I, T>(
+        &self,
+        conn: &mut zlink::Connection<S>,
+        authorized_groups: I,
+    ) -> Result<(), ControlError>
+    where
+        S: Socket,
+        S::ReadHalf: FetchPeerCredentials,
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let creds = conn
+            .peer_credentials()
+            .await
+            .map_err(|_| ControlError::PermissionDenied)?;
+
+        let mut groups: Vec<Gid> = creds.unix_supplementary_group_ids().to_vec();
+        groups.push(creds.unix_primary_group_id());
+
+        let groups = resolve_numeric_groups_to_names(groups);
+
+        if creds.unix_user_id().is_root()
+            || authorized_groups
+                .into_iter()
+                .any(|trusted| groups.contains(trusted.as_ref()))
+        {
+            info!(
+                "Privileged RPC allowed from user '{}'",
+                creds.unix_user_id()
+            );
+            Ok(())
+        } else {
+            tracing::warn!(
+                "Privileged RPC call attempt from user '{}' (groups: '{:?}') refused",
+                creds.unix_user_id(),
+                groups
+            );
+
+            Err(ControlError::PermissionDenied)
+        }
+    }
+}
+
 #[service(
     interface = "fr.gouv.portail.Control",
     vendor = "gouv",
-    product = "portail",
-    version = "0.1.0",
-    url = "https://github.com/cloud-gouv/portail"
+    product = env!("CARGO_PKG_NAME"),
+    version = env!("CARGO_PKG_VERSION"),
+    url = env!("CARGO_PKG_HOMEPAGE"),
 )]
 impl<Sock> Control
 where
@@ -97,42 +141,62 @@ where
         backend_id: Option<&str>,
         #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
     ) -> Result<(), ControlError> {
-        let r = conn
-            .peer_credentials()
-            .await
-            .map_err(|_| ControlError::PermissionDenied)?;
+        self.check_authorization(conn, self.settings.rpc.trusted_groups.iter())
+            .await?;
 
-        let mut groups: Vec<Gid> = r.unix_supplementary_group_ids().to_vec();
-        groups.push(r.unix_primary_group_id());
+        let mut state = self.state.write().await;
 
-        let groups = resolve_numeric_groups_to_names(groups);
-
-        if r.unix_user_id().is_root()
-            || self
-                .settings
-                .rpc
-                .trusted_groups
-                .iter()
-                .any(|trusted_group| groups.contains(trusted_group))
-        {
-            let mut state = self.state.write().await;
-
-            if let Some(backend_id) = backend_id {
-                if !self.settings.backends.contains_key(backend_id) {
-                    return Err(ControlError::BackendNotFound {
-                        provided_backend: backend_id.to_string(),
-                        available_backends: self.settings.backends.keys().cloned().collect(),
-                    });
-                }
-
-                state.default_backend = Some(backend_id.to_owned());
-            } else {
-                state.default_backend = None;
+        if let Some(backend_id) = backend_id {
+            if !state.backends.contains_key(backend_id) {
+                return Err(ControlError::BackendNotFound {
+                    provided_backend: backend_id.to_string(),
+                    available_backends: state.backends.keys().cloned().collect(),
+                });
             }
 
-            Ok(())
+            state.default_backend = Some(backend_id.to_owned());
         } else {
-            Err(ControlError::PermissionDenied)
+            state.default_backend = None;
+        }
+
+        Ok(())
+    }
+
+    async fn update_dynamic_backend(
+        &mut self,
+        backend_id: &str,
+        backend_spec: DynamicBackendSpec,
+        #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
+    ) -> Result<(), ControlError> {
+        self.check_authorization(conn, self.settings.rpc.admin_groups.iter())
+            .await?;
+
+        // This is not a dynamic backend, let's bail out.
+        if matches!(
+            self.settings.backends.get(backend_id),
+            Some(BackendSettings::KnownBackend(_))
+        ) {
+            return Err(ControlError::ImmutableBackend);
+        }
+
+        let mut state = self.state.write().await;
+        let new_backend: KnownBackend = backend_spec.try_into()?;
+
+        match state.backends.get_mut(backend_id) {
+            Some(backend) => {
+                info!(
+                    "Changed backend `{}` from `{:?}` to `{:?}`",
+                    backend_id, *backend, new_backend
+                );
+
+                *backend = BackendSettings::KnownBackend(new_backend);
+
+                Ok(())
+            }
+            None => Err(ControlError::BackendNotFound {
+                provided_backend: backend_id.to_string(),
+                available_backends: state.backends.keys().cloned().collect(),
+            }),
         }
     }
 
@@ -157,7 +221,7 @@ where
                 .keys()
                 .map(|backend_id|
                     // TODO: expose more information about the backend but safely!
-                    BackendInfo {
+                    BackendListItem {
                         id: backend_id.to_owned(),
                         current: cur_backend
                             .as_ref()

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -214,20 +214,35 @@ where
 
     async fn list_backends(&mut self) -> ListBackendsOutput {
         let cur_backend = self.state.read().await.default_backend.clone();
+        let backends = &self.state.read().await.backends;
         ListBackendsOutput {
-            backends: self
-                .settings
-                .backends
-                .keys()
-                .map(|backend_id|
-                    // TODO: expose more information about the backend but safely!
-                    BackendListItem {
-                        id: backend_id.to_owned(),
-                        current: cur_backend
-                            .as_ref()
-                            .map(|cur_backend_id| *cur_backend_id == *backend_id)
-                            .unwrap_or(false),
-                    })
+            backends: backends
+                .iter()
+                .map(|(backend_id, backend)| {
+                    let current = cur_backend
+                        .as_ref()
+                        .map(|cur_backend_id| *cur_backend_id == *backend_id)
+                        .unwrap_or(false);
+                    let id = backend_id.to_owned();
+
+                    match backend {
+                        BackendSettings::UnresolvedBackend => BackendListItem {
+                            id,
+                            current,
+                            dynamic: true,
+                            spec: None,
+                        },
+                        BackendSettings::KnownBackend(known) => BackendListItem {
+                            id,
+                            current,
+                            dynamic: matches!(
+                                self.settings.backends.get(backend_id.as_str()).unwrap_or_else(|| panic!("Broken invariant: backend {backend_id} exists in state but not in settings")),
+                                BackendSettings::UnresolvedBackend
+                            ),
+                            spec: Some(known.clone().into()),
+                        },
+                    }
+                })
                 .collect(),
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,7 @@
 //! Contains the state of the application and various state transitions APIs.
 
 use std::{
+    collections::HashMap,
     io::BufReader,
     sync::{Arc, atomic::AtomicUsize},
 };
@@ -12,7 +13,7 @@ use tokio_rustls::rustls::{
 };
 use tracing::{info, warn};
 
-use crate::config::Settings;
+use crate::config::{BackendSettings, Settings};
 use thiserror::Error;
 
 pub struct ServerCertificates<'a> {
@@ -21,6 +22,7 @@ pub struct ServerCertificates<'a> {
 }
 
 pub struct State {
+    pub backends: HashMap<String, BackendSettings>,
     pub default_backend: Option<String>,
     pub acl_rules: crate::acl::ACLRules,
     pub root_store: Option<Arc<tokio_rustls::rustls::RootCertStore>>,
@@ -161,6 +163,7 @@ pub struct Statistics {
 
 pub fn init(settings: &Settings) -> Result<State, InitError> {
     let mut state = State {
+        backends: settings.backends.clone(),
         default_backend: settings.default_backend.clone(),
         acl_rules: crate::acl::load_rules_from_file(
             &settings


### PR DESCRIPTION
This allows configuration of dynamic backends which are unresolved at runtime while allowing them to be type checked at ACL check time.

If you use dynamic backends, any routing to it will fail as there is still no way to update/resolve the dynamic backend with its information.

This adds `UpdateDynamicBackend` which allows you to update any backend marked dynamically as many times as you want. This is obviously a very dangerous RPC because it allows to go against the deployment-time configuration of proxies and enable an attacker to change a dynamic backend to a attacker-controlled location.

Therefore, in this same PR, we introduce `admin_groups` for RPC which are allowed to perform administrative-level RPCs.

The deployment plan is that you can either use `root` or a systemd unit `DynamicUser=true` with a supplementary group `portail-admin` (listed in `admin_groups`) to update the proxy **after the RPC socket is ready**.

TODO:

- think about the consequences of having only unresolved dynamic backends, should we wait until we get resolution to serve requests?

Fixes #98.