### PR TITLE
bench(proxy): introduce TLS-based Hyper proxy benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,12 +698,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -711,6 +727,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -760,9 +787,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1347,6 +1378,7 @@ dependencies = [
  "clap",
  "criterion",
  "fast-socks5",
+ "futures",
  "http",
  "http-body-util",
  "hyper",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +233,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -414,6 +462,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -493,6 +542,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +569,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -539,7 +619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1042,6 +1122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1152,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,10 +1171,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1087,6 +1202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1144,6 +1268,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -1211,6 +1345,7 @@ dependencies = [
  "insta",
  "nix",
  "rand",
+ "rcgen",
  "regex",
  "rustls-pki-types",
  "serde",
@@ -1310,6 +1445,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1382,6 +1531,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1391,7 +1549,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1658,16 +1816,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2135,7 +2304,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2386,6 +2555,34 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,18 @@ zlink = "^0.5"
 rustls-pki-types = "^1"
 
 [dev-dependencies]
-criterion = { version = "0.8.2", features = ["html_reports"] }
+criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }
 insta = "1.47.2"
 rand = "0.10.1"
+rcgen = "0.14.8"
+http-body-util = "0.1"
 
 [[bench]]
 name = "acl"
+harness = false
+
+[[bench]]
+name = "tls"
 harness = false
 
 [profile.dev.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ insta = "1.47.2"
 rand = "0.10.1"
 rcgen = "0.14.8"
 http-body-util = "0.1"
+futures = "0.3"
 
 [[bench]]
 name = "acl"

--- a/benches/tls.rs
+++ b/benches/tls.rs
@@ -1,0 +1,257 @@
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use http_body_util::{BodyExt, Empty, Full};
+use hyper::body::Bytes;
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use portail::{acl::ACLRules, proxy::client_tls::connect_using_tls_auth, state};
+use rcgen::{BasicConstraints, CertificateParams, IsCa, Issuer, KeyPair, PKCS_ECDSA_P256_SHA256};
+use tokio::{io::DuplexStream, sync::RwLock};
+use tokio_rustls::{
+    TlsAcceptor,
+    rustls::{
+        RootCertStore,
+        pki_types::{CertificateDer, PrivateKeyDer, ServerName},
+    },
+};
+
+fn empty_acl() -> ACLRules {
+    ACLRules::default()
+}
+
+struct Context {
+    state: Arc<RwLock<state::State>>,
+    acceptor: TlsAcceptor,
+}
+
+fn setup_context(root_count: usize) -> Context {
+    let mut roots = RootCertStore::empty();
+
+    let mut ca_key: Option<KeyPair> = None;
+    let mut ca_params: Option<CertificateParams> = None;
+
+    for i in 0..root_count {
+        let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+
+        let mut params = CertificateParams::new(vec![format!("CA {i}")]).unwrap();
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+
+        let cert = params.self_signed(&key).unwrap();
+
+        roots
+            .add(CertificateDer::from(cert.der().to_vec()))
+            .unwrap();
+
+        if i == 0 {
+            ca_key = Some(key);
+            ca_params = Some(params);
+        }
+    }
+
+    let ca_key = ca_key.expect("missing CA key");
+    let ca_params = ca_params.expect("missing CA params");
+    let issuer = Issuer::from_params(&ca_params, &ca_key);
+    let server_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+    let server_params = CertificateParams::new(vec!["localhost".into()]).unwrap();
+    let server_cert = server_params.signed_by(&server_key, &issuer).unwrap();
+
+    let mut server_config = tokio_rustls::rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(
+            vec![CertificateDer::from(server_cert.der().to_vec())],
+            PrivateKeyDer::Pkcs8(server_key.serialize_der().into()),
+        )
+        .unwrap();
+
+    server_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+    let state = state::State {
+        default_backend: None,
+        acl_rules: empty_acl(),
+        root_store: Some(Arc::new(roots)),
+        server_certificates: None,
+        client_cert_resolver: None,
+    };
+
+    Context {
+        state: Arc::new(RwLock::new(state)),
+        acceptor: TlsAcceptor::from(Arc::new(server_config)),
+    }
+}
+
+async fn serve(acceptor: TlsAcceptor, io: DuplexStream) {
+    let tls = match acceptor.accept(io).await {
+        Ok(tls) => tls,
+        Err(_) => return,
+    };
+
+    let alpn = tls.get_ref().1.alpn_protocol().map(|v| v.to_vec());
+    let service = hyper::service::service_fn(|_| async {
+        Ok::<_, hyper::Error>(hyper::Response::new(Full::new(Bytes::from_static(b"OK"))))
+    });
+
+    let io = TokioIo::new(tls);
+
+    match alpn.as_deref() {
+        Some(b"h2") => {
+            let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+                .serve_connection(io, service)
+                .await;
+        }
+
+        _ => {
+            let _ = hyper::server::conn::http1::Builder::new()
+                .serve_connection(io, service)
+                .await;
+        }
+    }
+}
+
+async fn http1_session(acceptor: TlsAcceptor, state: Arc<RwLock<state::State>>, requests: usize) {
+    let (client, server) = tokio::io::duplex(1024 * 1024);
+
+    let server_task = tokio::spawn(serve(acceptor, server));
+
+    let tls = connect_using_tls_auth(
+        client,
+        ServerName::try_from("localhost").unwrap(),
+        state,
+        vec![b"http/1.1".to_vec()],
+    )
+    .await
+    .unwrap();
+
+    let io = TokioIo::new(tls);
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+
+    let driver = tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    for _ in 0..requests {
+        let req = hyper::Request::builder()
+            .uri("/")
+            .header("host", "localhost")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+
+        let response = sender.send_request(req).await.unwrap();
+
+        response.collect().await.unwrap();
+    }
+
+    drop(sender);
+
+    driver.abort();
+    server_task.abort();
+}
+
+async fn http2_session(
+    acceptor: TlsAcceptor,
+    state: Arc<RwLock<state::State>>,
+    concurrency: usize,
+) {
+    let (client, server) = tokio::io::duplex(1024 * 1024);
+
+    let server_task = tokio::spawn(serve(acceptor, server));
+
+    let tls = connect_using_tls_auth(
+        client,
+        ServerName::try_from("localhost").unwrap(),
+        state,
+        vec![b"h2".to_vec()],
+    )
+    .await
+    .unwrap();
+
+    let io = TokioIo::new(tls);
+
+    let (sender, conn) = hyper::client::conn::http2::handshake(TokioExecutor::new(), io)
+        .await
+        .unwrap();
+
+    let driver = tokio::spawn(async move {
+        let _ = conn.await;
+    });
+
+    let mut tasks = Vec::with_capacity(concurrency);
+
+    for _ in 0..concurrency {
+        let mut sender = sender.clone();
+
+        tasks.push(tokio::spawn(async move {
+            let req = hyper::Request::builder()
+                .uri("/")
+                .header("host", "localhost")
+                .body(Empty::<Bytes>::new())
+                .unwrap();
+
+            let response = sender.send_request(req).await.unwrap();
+
+            response.collect().await.unwrap();
+        }));
+    }
+
+    for task in tasks {
+        task.await.unwrap();
+    }
+
+    drop(sender);
+
+    driver.abort();
+    server_task.abort();
+}
+
+fn bench_proxy(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let ctx = setup_context(10);
+
+    let mut group = c.benchmark_group("proxy_http1");
+
+    for requests in [1usize, 5, 20] {
+        group.throughput(Throughput::Elements(requests as u64));
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(requests),
+            &requests,
+            |b, &requests| {
+                let acceptor = ctx.acceptor.clone();
+
+                let state = ctx.state.clone();
+
+                b.to_async(&rt)
+                    .iter(|| http1_session(acceptor.clone(), state.clone(), requests));
+            },
+        );
+    }
+
+    group.finish();
+
+    let mut group = c.benchmark_group("proxy_http2");
+
+    for concurrency in [1usize, 8, 32] {
+        group.throughput(Throughput::Elements(concurrency as u64));
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(concurrency),
+            &concurrency,
+            |b, &concurrency| {
+                let acceptor = ctx.acceptor.clone();
+
+                let state = ctx.state.clone();
+
+                b.to_async(&rt)
+                    .iter(|| http2_session(acceptor.clone(), state.clone(), concurrency));
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_proxy);
+criterion_main!(benches);

--- a/benches/tls.rs
+++ b/benches/tls.rs
@@ -27,8 +27,8 @@ struct Context {
 fn setup_context(root_count: usize) -> Context {
     let mut roots = RootCertStore::empty();
 
-    let mut ca_key: Option<KeyPair> = None;
-    let mut ca_params: Option<CertificateParams> = None;
+    let mut ca_key = None;
+    let mut ca_params = None;
 
     for i in 0..root_count {
         let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
@@ -48,8 +48,9 @@ fn setup_context(root_count: usize) -> Context {
         }
     }
 
-    let ca_key = ca_key.expect("missing CA key");
-    let ca_params = ca_params.expect("missing CA params");
+    let ca_key = ca_key.unwrap();
+    let ca_params = ca_params.unwrap();
+
     let issuer = Issuer::from_params(&ca_params, &ca_key);
     let server_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
     let server_params = CertificateParams::new(vec!["localhost".into()]).unwrap();
@@ -81,11 +82,12 @@ fn setup_context(root_count: usize) -> Context {
 
 async fn serve(acceptor: TlsAcceptor, io: DuplexStream) {
     let tls = match acceptor.accept(io).await {
-        Ok(tls) => tls,
+        Ok(v) => v,
         Err(_) => return,
     };
 
-    let alpn = tls.get_ref().1.alpn_protocol().map(|v| v.to_vec());
+    let alpn = tls.get_ref().1.alpn_protocol().map(|x| x.to_vec());
+
     let service = hyper::service::service_fn(|_| async {
         Ok::<_, hyper::Error>(hyper::Response::new(Full::new(Bytes::from_static(b"OK"))))
     });
@@ -107,99 +109,107 @@ async fn serve(acceptor: TlsAcceptor, io: DuplexStream) {
     }
 }
 
-async fn http1_session(acceptor: TlsAcceptor, state: Arc<RwLock<state::State>>, requests: usize) {
-    let (client, server) = tokio::io::duplex(1024 * 1024);
+struct Http1Session {
+    sender: hyper::client::conn::http1::SendRequest<Empty<Bytes>>,
+    _driver: tokio::task::JoinHandle<()>,
+    _server: tokio::task::JoinHandle<()>,
+}
 
-    let server_task = tokio::spawn(serve(acceptor, server));
+impl Http1Session {
+    async fn new(acceptor: TlsAcceptor, state: Arc<RwLock<state::State>>) -> Self {
+        let (client, server) = tokio::io::duplex(1024 * 1024);
+        let server_task = tokio::spawn(serve(acceptor, server));
+        let tls = connect_using_tls_auth(
+            client,
+            ServerName::try_from("localhost").unwrap(),
+            state,
+            vec![b"http/1.1".to_vec()],
+        )
+        .await
+        .unwrap();
 
-    let tls = connect_using_tls_auth(
-        client,
-        ServerName::try_from("localhost").unwrap(),
-        state,
-        vec![b"http/1.1".to_vec()],
-    )
-    .await
-    .unwrap();
+        let io = TokioIo::new(tls);
+        let (sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        let driver = tokio::spawn(async move {
+            let _ = conn.await;
+        });
 
-    let io = TokioIo::new(tls);
-    let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+        Self {
+            sender,
+            _driver: driver,
+            _server: server_task,
+        }
+    }
 
-    let driver = tokio::spawn(async move {
-        let _ = conn.await;
-    });
-
-    for _ in 0..requests {
+    async fn request(&mut self) {
         let req = hyper::Request::builder()
             .uri("/")
             .header("host", "localhost")
             .body(Empty::<Bytes>::new())
             .unwrap();
 
-        let response = sender.send_request(req).await.unwrap();
-
+        let response = self.sender.send_request(req).await.unwrap();
         response.collect().await.unwrap();
     }
-
-    drop(sender);
-
-    driver.abort();
-    server_task.abort();
 }
 
-async fn http2_session(
-    acceptor: TlsAcceptor,
-    state: Arc<RwLock<state::State>>,
-    concurrency: usize,
-) {
-    let (client, server) = tokio::io::duplex(1024 * 1024);
+struct Http2Session {
+    sender: hyper::client::conn::http2::SendRequest<Empty<Bytes>>,
+    _driver: tokio::task::JoinHandle<()>,
+    _server: tokio::task::JoinHandle<()>,
+}
 
-    let server_task = tokio::spawn(serve(acceptor, server));
-
-    let tls = connect_using_tls_auth(
-        client,
-        ServerName::try_from("localhost").unwrap(),
-        state,
-        vec![b"h2".to_vec()],
-    )
-    .await
-    .unwrap();
-
-    let io = TokioIo::new(tls);
-
-    let (sender, conn) = hyper::client::conn::http2::handshake(TokioExecutor::new(), io)
+impl Http2Session {
+    async fn new(acceptor: TlsAcceptor, state: Arc<RwLock<state::State>>) -> Self {
+        let (client, server) = tokio::io::duplex(1024 * 1024);
+        let server_task = tokio::spawn(serve(acceptor, server));
+        let tls = connect_using_tls_auth(
+            client,
+            ServerName::try_from("localhost").unwrap(),
+            state,
+            vec![b"h2".to_vec()],
+        )
         .await
         .unwrap();
 
-    let driver = tokio::spawn(async move {
-        let _ = conn.await;
-    });
+        let io = TokioIo::new(tls);
+        let (sender, conn) = hyper::client::conn::http2::handshake(TokioExecutor::new(), io)
+            .await
+            .unwrap();
+        let driver = tokio::spawn(async move {
+            let _ = conn.await;
+        });
 
-    let mut tasks = Vec::with_capacity(concurrency);
-
-    for _ in 0..concurrency {
-        let mut sender = sender.clone();
-
-        tasks.push(tokio::spawn(async move {
-            let req = hyper::Request::builder()
-                .uri("/")
-                .header("host", "localhost")
-                .body(Empty::<Bytes>::new())
-                .unwrap();
-
-            let response = sender.send_request(req).await.unwrap();
-
-            response.collect().await.unwrap();
-        }));
+        Self {
+            sender,
+            _driver: driver,
+            _server: server_task,
+        }
     }
 
-    for task in tasks {
-        task.await.unwrap();
+    async fn batch(&self, concurrency: usize) {
+        let mut tasks = Vec::with_capacity(concurrency);
+
+        for _ in 0..concurrency {
+            let mut sender = self.sender.clone();
+
+            tasks.push(tokio::spawn(async move {
+                let req = hyper::Request::builder()
+                    .uri("/")
+                    .header("host", "localhost")
+                    .body(Empty::<Bytes>::new())
+                    .unwrap();
+
+                let response = sender.send_request(req).await.unwrap();
+
+                response.collect().await.unwrap();
+            }));
+        }
+
+        for t in tasks {
+            t.await.unwrap();
+        }
     }
-
-    drop(sender);
-
-    driver.abort();
-    server_task.abort();
 }
 
 fn bench_proxy(c: &mut Criterion) {
@@ -210,47 +220,106 @@ fn bench_proxy(c: &mut Criterion) {
 
     let ctx = setup_context(10);
 
-    let mut group = c.benchmark_group("proxy_http1");
+    {
+        let mut group = c.benchmark_group("http1_keepalive");
 
-    for requests in [1usize, 5, 20] {
-        group.throughput(Throughput::Elements(requests as u64));
+        for requests in [1usize, 5, 20] {
+            group.throughput(Throughput::Elements(requests as u64));
 
-        group.bench_with_input(
-            BenchmarkId::from_parameter(requests),
-            &requests,
-            |b, &requests| {
-                let acceptor = ctx.acceptor.clone();
+            group.bench_with_input(
+                BenchmarkId::from_parameter(requests),
+                &requests,
+                |b, &requests| {
+                    let mut session =
+                        rt.block_on(Http1Session::new(ctx.acceptor.clone(), ctx.state.clone()));
 
-                let state = ctx.state.clone();
+                    b.iter_custom(|iters| {
+                        let start = std::time::Instant::now();
+                        rt.block_on(async {
+                            for _ in 0..iters {
+                                for _ in 0..requests {
+                                    session.request().await;
+                                }
+                            }
+                        });
+                        start.elapsed()
+                    });
+                },
+            );
+        }
 
-                b.to_async(&rt)
-                    .iter(|| http1_session(acceptor.clone(), state.clone(), requests));
-            },
-        );
+        group.finish();
     }
 
-    group.finish();
+    {
+        let mut group = c.benchmark_group("http2_persistent");
 
-    let mut group = c.benchmark_group("proxy_http2");
+        for requests in [1usize, 5, 20] {
+            group.throughput(Throughput::Elements(requests as u64));
 
-    for concurrency in [1usize, 8, 32] {
-        group.throughput(Throughput::Elements(concurrency as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(requests),
+                &requests,
+                |b, &requests| {
+                    let session =
+                        rt.block_on(Http2Session::new(ctx.acceptor.clone(), ctx.state.clone()));
 
-        group.bench_with_input(
-            BenchmarkId::from_parameter(concurrency),
-            &concurrency,
-            |b, &concurrency| {
-                let acceptor = ctx.acceptor.clone();
+                    b.iter_custom(|iters| {
+                        let start = std::time::Instant::now();
+                        rt.block_on(async {
+                            for _ in 0..iters {
+                                for _ in 0..requests {
+                                    let mut s = session.sender.clone();
 
-                let state = ctx.state.clone();
+                                    let req = hyper::Request::builder()
+                                        .uri("/")
+                                        .header("host", "localhost")
+                                        .body(Empty::<Bytes>::new())
+                                        .unwrap();
 
-                b.to_async(&rt)
-                    .iter(|| http2_session(acceptor.clone(), state.clone(), concurrency));
-            },
-        );
+                                    let response = s.send_request(req).await.unwrap();
+
+                                    response.collect().await.unwrap();
+                                }
+                            }
+                        });
+                        start.elapsed()
+                    });
+                },
+            );
+        }
+
+        group.finish();
     }
 
-    group.finish();
+    {
+        let mut group = c.benchmark_group("http2_multiplexed");
+
+        for concurrency in [1usize, 8, 32] {
+            group.throughput(Throughput::Elements(concurrency as u64));
+
+            group.bench_with_input(
+                BenchmarkId::from_parameter(concurrency),
+                &concurrency,
+                |b, &concurrency| {
+                    let session =
+                        rt.block_on(Http2Session::new(ctx.acceptor.clone(), ctx.state.clone()));
+
+                    b.iter_custom(|iters| {
+                        let start = std::time::Instant::now();
+                        rt.block_on(async {
+                            for _ in 0..iters {
+                                session.batch(concurrency).await;
+                            }
+                        });
+                        start.elapsed()
+                    });
+                },
+            );
+        }
+
+        group.finish();
+    }
 }
 
 criterion_group!(benches, bench_proxy);

--- a/benches/tls.rs
+++ b/benches/tls.rs
@@ -1,7 +1,13 @@
-use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    future::poll_fn,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use http_body_util::{BodyExt, Empty, Full};
+use futures::future::join_all;
+use http_body_util::{BodyExt, Empty};
 use hyper::body::Bytes;
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use portail::{acl::ACLRules, proxy::client_tls::connect_using_tls_auth, state};
@@ -15,6 +21,27 @@ use tokio_rustls::{
     },
 };
 
+const DUPLEX_BUF: usize = 64 * 1024;
+const REQUEST_COUNTS: &[usize] = &[1, 5, 20];
+const ROOT_COUNTS: &[usize] = &[1, 10, 100];
+
+#[derive(Clone, Copy)]
+enum Protocol {
+    Http1,
+    Http2,
+}
+
+#[derive(Clone, Copy)]
+enum BenchMode {
+    Sequential,
+    Multiplexed,
+}
+
+enum Sender {
+    Http1(hyper::client::conn::http1::SendRequest<Empty<Bytes>>),
+    Http2(hyper::client::conn::http2::SendRequest<Empty<Bytes>>),
+}
+
 fn empty_acl() -> ACLRules {
     ACLRules::default()
 }
@@ -27,10 +54,17 @@ struct Context {
 fn setup_context(root_count: usize) -> Context {
     let mut roots = RootCertStore::empty();
 
-    let mut ca_key = None;
-    let mut ca_params = None;
+    let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
+    let mut ca_params = CertificateParams::new(vec!["CA 0".to_string()]).unwrap();
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
 
-    for i in 0..root_count {
+    let cert = ca_params.self_signed(&ca_key).unwrap();
+
+    roots
+        .add(CertificateDer::from(cert.der().to_vec()))
+        .unwrap();
+
+    for i in 1..root_count {
         let key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
 
         let mut params = CertificateParams::new(vec![format!("CA {i}")]).unwrap();
@@ -41,19 +75,20 @@ fn setup_context(root_count: usize) -> Context {
         roots
             .add(CertificateDer::from(cert.der().to_vec()))
             .unwrap();
-
-        if i == 0 {
-            ca_key = Some(key);
-            ca_params = Some(params);
-        }
     }
 
-    let ca_key = ca_key.unwrap();
-    let ca_params = ca_params.unwrap();
-
     let issuer = Issuer::from_params(&ca_params, &ca_key);
+
     let server_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
-    let server_params = CertificateParams::new(vec!["localhost".into()]).unwrap();
+
+    let mut server_params = CertificateParams::new(vec![]).unwrap();
+    server_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "localhost");
+    server_params
+        .subject_alt_names
+        .push(rcgen::SanType::DnsName("localhost".try_into().unwrap()));
+
     let server_cert = server_params.signed_by(&server_key, &issuer).unwrap();
 
     let mut server_config = tokio_rustls::rustls::ServerConfig::builder()
@@ -72,6 +107,7 @@ fn setup_context(root_count: usize) -> Context {
         root_store: Some(Arc::new(roots)),
         server_certificates: None,
         client_cert_resolver: None,
+        backends: HashMap::new(),
     };
 
     Context {
@@ -89,7 +125,7 @@ async fn serve(acceptor: TlsAcceptor, io: DuplexStream) {
     let alpn = tls.get_ref().1.alpn_protocol().map(|x| x.to_vec());
 
     let service = hyper::service::service_fn(|_| async {
-        Ok::<_, hyper::Error>(hyper::Response::new(Full::new(Bytes::from_static(b"OK"))))
+        Ok::<_, hyper::Error>(hyper::Response::new(Empty::<Bytes>::new()))
     });
 
     let io = TokioIo::new(tls);
@@ -100,7 +136,6 @@ async fn serve(acceptor: TlsAcceptor, io: DuplexStream) {
                 .serve_connection(io, service)
                 .await;
         }
-
         _ => {
             let _ = hyper::server::conn::http1::Builder::new()
                 .serve_connection(io, service)
@@ -109,217 +144,198 @@ async fn serve(acceptor: TlsAcceptor, io: DuplexStream) {
     }
 }
 
-struct Http1Session {
-    sender: hyper::client::conn::http1::SendRequest<Empty<Bytes>>,
-    _driver: tokio::task::JoinHandle<()>,
-    _server: tokio::task::JoinHandle<()>,
+struct RequestTemplate {
+    uri: http::Uri,
+    host: http::HeaderValue,
 }
 
-impl Http1Session {
-    async fn new(acceptor: TlsAcceptor, state: Arc<RwLock<state::State>>) -> Self {
-        let (client, server) = tokio::io::duplex(1024 * 1024);
+impl RequestTemplate {
+    fn new() -> Self {
+        Self {
+            uri: "/".parse().unwrap(),
+            host: "localhost".parse().unwrap(),
+        }
+    }
+
+    fn build(&self) -> hyper::Request<Empty<Bytes>> {
+        hyper::Request::builder()
+            .uri(self.uri.clone())
+            .header("host", self.host.clone())
+            .body(Empty::new())
+            .unwrap()
+    }
+}
+
+struct SessionKeeper {
+    driver: tokio::task::JoinHandle<()>,
+    server: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for SessionKeeper {
+    fn drop(&mut self) {
+        self.driver.abort();
+        self.server.abort();
+    }
+}
+
+struct Session {
+    sender: Sender,
+    _keeper: SessionKeeper,
+}
+
+impl Session {
+    async fn new(
+        protocol: Protocol,
+        acceptor: TlsAcceptor,
+        state: Arc<RwLock<state::State>>,
+    ) -> Self {
+        let (client, server) = tokio::io::duplex(DUPLEX_BUF);
         let server_task = tokio::spawn(serve(acceptor, server));
+
+        let alpn = match protocol {
+            Protocol::Http1 => vec![b"http/1.1".to_vec()],
+            Protocol::Http2 => vec![b"h2".to_vec()],
+        };
+
         let tls = connect_using_tls_auth(
             client,
             ServerName::try_from("localhost").unwrap(),
             state,
-            vec![b"http/1.1".to_vec()],
+            alpn,
         )
         .await
         .unwrap();
 
         let io = TokioIo::new(tls);
-        let (sender, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
-        let driver = tokio::spawn(async move {
-            let _ = conn.await;
-        });
 
-        Self {
-            sender,
-            _driver: driver,
-            _server: server_task,
-        }
-    }
-
-    async fn request(&mut self) {
-        let req = hyper::Request::builder()
-            .uri("/")
-            .header("host", "localhost")
-            .body(Empty::<Bytes>::new())
-            .unwrap();
-
-        let response = self.sender.send_request(req).await.unwrap();
-        response.collect().await.unwrap();
-    }
-}
-
-struct Http2Session {
-    sender: hyper::client::conn::http2::SendRequest<Empty<Bytes>>,
-    _driver: tokio::task::JoinHandle<()>,
-    _server: tokio::task::JoinHandle<()>,
-}
-
-impl Http2Session {
-    async fn new(acceptor: TlsAcceptor, state: Arc<RwLock<state::State>>) -> Self {
-        let (client, server) = tokio::io::duplex(1024 * 1024);
-        let server_task = tokio::spawn(serve(acceptor, server));
-        let tls = connect_using_tls_auth(
-            client,
-            ServerName::try_from("localhost").unwrap(),
-            state,
-            vec![b"h2".to_vec()],
-        )
-        .await
-        .unwrap();
-
-        let io = TokioIo::new(tls);
-        let (sender, conn) = hyper::client::conn::http2::handshake(TokioExecutor::new(), io)
-            .await
-            .unwrap();
-        let driver = tokio::spawn(async move {
-            let _ = conn.await;
-        });
-
-        Self {
-            sender,
-            _driver: driver,
-            _server: server_task,
-        }
-    }
-
-    async fn batch(&self, concurrency: usize) {
-        let mut tasks = Vec::with_capacity(concurrency);
-
-        for _ in 0..concurrency {
-            let mut sender = self.sender.clone();
-
-            tasks.push(tokio::spawn(async move {
-                let req = hyper::Request::builder()
-                    .uri("/")
-                    .header("host", "localhost")
-                    .body(Empty::<Bytes>::new())
+        let (sender, driver) = match protocol {
+            Protocol::Http1 => {
+                let (s, conn) = hyper::client::conn::http1::handshake(io).await.unwrap();
+                let d = tokio::spawn(async move {
+                    let _ = conn.await;
+                });
+                (Sender::Http1(s), d)
+            }
+            Protocol::Http2 => {
+                let (s, conn) = hyper::client::conn::http2::handshake(TokioExecutor::new(), io)
+                    .await
                     .unwrap();
+                let d = tokio::spawn(async move {
+                    let _ = conn.await;
+                });
+                (Sender::Http2(s), d)
+            }
+        };
 
-                let response = sender.send_request(req).await.unwrap();
-
-                response.collect().await.unwrap();
-            }));
-        }
-
-        for t in tasks {
-            t.await.unwrap();
+        Self {
+            sender,
+            _keeper: SessionKeeper {
+                driver,
+                server: server_task,
+            },
         }
     }
+
+    async fn execute(&mut self, mode: BenchMode, count: usize, template: &RequestTemplate) {
+        match mode {
+            BenchMode::Sequential => {
+                for _ in 0..count {
+                    let req = template.build();
+                    match &mut self.sender {
+                        Sender::Http1(s) => {
+                            poll_fn(|cx| s.poll_ready(cx)).await.unwrap();
+                            let resp = s.send_request(req).await.unwrap();
+                            resp.collect().await.unwrap();
+                        }
+                        Sender::Http2(s) => {
+                            poll_fn(|cx| s.poll_ready(cx)).await.unwrap();
+                            let resp = s.send_request(req).await.unwrap();
+                            resp.collect().await.unwrap();
+                        }
+                    }
+                }
+            }
+            BenchMode::Multiplexed => {
+                if let Sender::Http2(s) = &self.sender {
+                    let futs = (0..count).map(|_| {
+                        let mut sender = s.clone();
+                        let req = template.build();
+                        async move {
+                            poll_fn(|cx| sender.poll_ready(cx)).await.unwrap();
+                            let resp = sender.send_request(req).await.unwrap();
+                            resp.collect().await.unwrap();
+                        }
+                    });
+                    join_all(futs).await;
+                }
+            }
+        }
+    }
+}
+
+fn run_bench_group(
+    c: &mut Criterion,
+    rt: &tokio::runtime::Runtime,
+    group_name: &str,
+    protocol: Protocol,
+    mode: BenchMode,
+) {
+    let mut group = c.benchmark_group(group_name);
+    group.warm_up_time(Duration::from_secs(1));
+
+    for &count in REQUEST_COUNTS {
+        group.throughput(Throughput::Elements(count as u64));
+
+        let ctx = setup_context(ROOT_COUNTS[1]);
+        let template = RequestTemplate::new();
+
+        group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, &count| {
+            let mut session = rt.block_on(Session::new(
+                protocol,
+                ctx.acceptor.clone(),
+                ctx.state.clone(),
+            ));
+            b.iter_custom(|iters| {
+                let start = Instant::now();
+                rt.block_on(async {
+                    for _ in 0..iters {
+                        session.execute(mode, count, &template).await;
+                    }
+                });
+                start.elapsed()
+            });
+        });
+    }
+    group.finish();
 }
 
 fn bench_proxy(c: &mut Criterion) {
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap();
 
-    let ctx = setup_context(10);
-
-    {
-        let mut group = c.benchmark_group("http1_keepalive");
-
-        for requests in [1usize, 5, 20] {
-            group.throughput(Throughput::Elements(requests as u64));
-
-            group.bench_with_input(
-                BenchmarkId::from_parameter(requests),
-                &requests,
-                |b, &requests| {
-                    let mut session =
-                        rt.block_on(Http1Session::new(ctx.acceptor.clone(), ctx.state.clone()));
-
-                    b.iter_custom(|iters| {
-                        let start = std::time::Instant::now();
-                        rt.block_on(async {
-                            for _ in 0..iters {
-                                for _ in 0..requests {
-                                    session.request().await;
-                                }
-                            }
-                        });
-                        start.elapsed()
-                    });
-                },
-            );
-        }
-
-        group.finish();
-    }
-
-    {
-        let mut group = c.benchmark_group("http2_persistent");
-
-        for requests in [1usize, 5, 20] {
-            group.throughput(Throughput::Elements(requests as u64));
-
-            group.bench_with_input(
-                BenchmarkId::from_parameter(requests),
-                &requests,
-                |b, &requests| {
-                    let session =
-                        rt.block_on(Http2Session::new(ctx.acceptor.clone(), ctx.state.clone()));
-
-                    b.iter_custom(|iters| {
-                        let start = std::time::Instant::now();
-                        rt.block_on(async {
-                            for _ in 0..iters {
-                                for _ in 0..requests {
-                                    let mut s = session.sender.clone();
-
-                                    let req = hyper::Request::builder()
-                                        .uri("/")
-                                        .header("host", "localhost")
-                                        .body(Empty::<Bytes>::new())
-                                        .unwrap();
-
-                                    let response = s.send_request(req).await.unwrap();
-
-                                    response.collect().await.unwrap();
-                                }
-                            }
-                        });
-                        start.elapsed()
-                    });
-                },
-            );
-        }
-
-        group.finish();
-    }
-
-    {
-        let mut group = c.benchmark_group("http2_multiplexed");
-
-        for concurrency in [1usize, 8, 32] {
-            group.throughput(Throughput::Elements(concurrency as u64));
-
-            group.bench_with_input(
-                BenchmarkId::from_parameter(concurrency),
-                &concurrency,
-                |b, &concurrency| {
-                    let session =
-                        rt.block_on(Http2Session::new(ctx.acceptor.clone(), ctx.state.clone()));
-
-                    b.iter_custom(|iters| {
-                        let start = std::time::Instant::now();
-                        rt.block_on(async {
-                            for _ in 0..iters {
-                                session.batch(concurrency).await;
-                            }
-                        });
-                        start.elapsed()
-                    });
-                },
-            );
-        }
-
-        group.finish();
-    }
+    run_bench_group(
+        c,
+        &rt,
+        "http1_keepalive",
+        Protocol::Http1,
+        BenchMode::Sequential,
+    );
+    run_bench_group(
+        c,
+        &rt,
+        "http2_sequential",
+        Protocol::Http2,
+        BenchMode::Sequential,
+    );
+    run_bench_group(
+        c,
+        &rt,
+        "http2_multiplexed",
+        Protocol::Http2,
+        BenchMode::Multiplexed,
+    );
 }
 
 criterion_group!(benches, bench_proxy);

--- a/src/acl/hir.rs
+++ b/src/acl/hir.rs
@@ -22,7 +22,7 @@ pub struct PolicyDefinition {
     pub action: Action,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct ACLHir {
     pub(crate) routes: Vec<RouteDefinition>,
     pub(crate) policies: Vec<PolicyDefinition>,

--- a/src/acl/mod.rs
+++ b/src/acl/mod.rs
@@ -13,20 +13,9 @@ use thiserror::Error;
 
 use crate::config::Settings;
 
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct ACLRules {
     pub hir: ACLHir,
-}
-
-impl Default for ACLRules {
-    fn default() -> Self {
-        Self {
-            hir: ACLHir {
-                routes: Vec::new(),
-                policies: Vec::new(),
-            },
-        }
-    }
 }
 
 #[derive(Debug, Error)]

--- a/src/acl/mod.rs
+++ b/src/acl/mod.rs
@@ -18,6 +18,17 @@ pub struct ACLRules {
     pub hir: ACLHir,
 }
 
+impl Default for ACLRules {
+    fn default() -> Self {
+        Self {
+            hir: ACLHir {
+                routes: Vec::new(),
+                policies: Vec::new(),
+            },
+        }
+    }
+}
+
 #[derive(Debug, Error)]
 pub enum LoadError {
     #[error("While reading the ACL rules: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod acl;
 pub mod config;
+pub mod proxy;
+pub mod state;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -14,7 +14,7 @@ use tracing::error;
 
 use crate::{config::Settings, proxy::context::InitialRequestContext, state::State};
 
-mod client_tls;
+pub mod client_tls;
 mod context;
 mod http_connect;
 mod protocol_detect;


### PR DESCRIPTION
Create a Criterion-based benchmark to evaluate proxy performance under HTTP/1.1 and HTTP/2.

The benchmark currently measures:
* Request lifecycle through the proxy:
   * TLS handshake
   * ALPN negotiation (HTTP/1.1 vs HTTP/2)
    * Hyper client/server request execution
    * Response collection overhead
* Comparative performance between:
    * HTTP/1.1 sequential request handling
    * HTTP/2 multiplexed streams under varying concurrency levels

TODO:
- [x]  Enable persistent connection reuse (HTTP/1.1 keep-alive, HTTP/2 single long-lived connection)
- [ ] Separate proxy layers (isolate TLS cost vs HTTP parsing vs routing logic)
- [ ] Add metrics decomposition
