### PR TITLE
fix: change the pointer type for a platform independant type

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -38,7 +38,7 @@ fn resolve_numeric_groups_to_names(gids: Vec<Gid>) -> HashSet<String> {
                 nix::libc::getgrgid_r(
                     gid.as_raw(),
                     &mut grp,
-                    buf.as_mut_ptr() as *mut i8,
+                    buf.as_mut_ptr().cast::<nix::libc::c_char>(),
                     buf.len(),
                     &mut grp_ptr,
                 )


### PR DESCRIPTION
This fixes the following error in a NixOS VM, in a plateform independent manner:

```
what is this error:
error[E0308]: mismatched types
    --> src/rpc/mod.rs:42:21
     |
  39 |                 nix::libc::getgrgid_r(
     |                 --------------------- arguments to this function are incorrect
...
  42 |                     buf.as_mut_ptr() as *mut i8,
     |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*mut u8`, found `*mut i8`
     |
     = note: expected raw pointer `*mut u8`
                found raw pointer `*mut i8`
note: function defined here
    --> /build/cargo-vendor-dir/libc-0.2.186/src/unix/linux_like/linux_l4re_shared.rs:1857:12
     |
1857 |     pub fn getgrgid_r(
     |            ^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
```