### PR TITLE
Prometheus metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,7 +1218,9 @@ dependencies = [
  "hyper",
  "hyper-util",
  "insta",
+ "lazy_static",
  "nix",
+ "prometheus",
  "rand",
  "regex",
  "rustls-pki-types",
@@ -1260,6 +1262,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = { version = "^4", features = ["derive", "string"] }
 fast-socks5 = "^1"
 http = "^1"
 http-body-util = "0.1.3"
-hyper = { version = "^1", features = ["full"] }
+hyper = { version = "^1", features = ["full", "http1"] }
 hyper-util = { version = "^0.1", features = ["tokio", "server", "http1"] }
 nix = { version = "^0.31", features = ["socket", "uio", "net"] }
 regex = "^1"
@@ -32,6 +32,8 @@ zlink = "^0.5"
 rustls-pki-types = "^1"
 uuid = { version = "1.23.3", features = ["v4"] }
 tracing-appender = "0.2.5"
+prometheus = "0.14.0"
+lazy_static = "1.5.0"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -79,6 +79,11 @@ in
         description = "Proxy listen stream in the systemd.socket(5) ListenStream= syntax.";
       };
 
+      metricsPort = mkOption {
+        type = types.port;
+        default = 10992;
+      };
+
       settings = mkOption {
         type = toml.type;
         description = "Settings for the proxy.";
@@ -119,6 +124,17 @@ in
           ListenStream = "/run/fr.gouv.portail.Control";
           PassCredentials = true;
           FileDescriptorName = "control";
+        };
+
+        wantedBy = [ "sockets.target" ];
+      };
+      portail-metrics = {
+        description = "Portail metrics sockets";
+        socketConfig = {
+          Service = "portail.service";
+          Accept = "no";
+          ListenStream = "127.0.0.1:${toString cfg.metricsPort}";
+          FileDescriptorName = "metrics";
         };
 
         wantedBy = [ "sockets.target" ];

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,1 @@
-cargo build; systemd-socket-activate --now --fdname proxy:control -E RUST_LOG=debug --listen 127.0.0.1:8000 --listen $(pwd)/fr.gouv.portail.Control ./target/debug/portail daemon --config ./config.toml
+cargo build; systemd-socket-activate --now --fdname proxy:control:metrics -E RUST_LOG=debug --listen [::1]:8000 --listen $(pwd)/fr.gouv.portail.Control --listen $(pwd)/fr.gouv.portail.Metrics ./target/debug/portail daemon --config ./config.toml

--- a/src/acl/ast.rs
+++ b/src/acl/ast.rs
@@ -47,6 +47,16 @@ pub enum Action {
     Redirect(Uri),
 }
 
+impl Action {
+    pub fn to_label(&self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Deny(_) => "deny",
+            Self::Redirect(_) => "redirect",
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Expression {
     Or(Box<Expression>, Box<Expression>),

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use crate::systemd::sd_notify_ready;
 mod acl;
 mod config;
 mod logging;
+mod metrics;
 mod proxy;
 mod rpc;
 mod state;
@@ -94,6 +95,8 @@ enum Commands {
         #[arg(long, value_name = "ADDRESS")]
         /// Address to bind the proxy to when the daemon must create the socket itself
         bind_proxy_address: Option<String>,
+        #[arg(long, value_name = "ADDRESS")]
+        bind_metrics_address: Option<String>,
         #[arg(long, value_name = "FILE")]
         /// Path where to create the RPC socket if the daemon must create it itself
         bind_rpc_socket: Option<String>,
@@ -270,6 +273,7 @@ async fn main() -> Result<()> {
         Commands::Daemon {
             config,
             bind_proxy_address,
+            bind_metrics_address,
             bind_rpc_socket,
             log_preset,
         } => {
@@ -309,11 +313,24 @@ async fn main() -> Result<()> {
                 tokio::net::UnixListener::from_std(std)?
             };
 
+            let metrics_listener = if let Some(metrics_address) = bind_metrics_address {
+                tokio::net::TcpListener::bind(metrics_address).await?
+            } else {
+                let metrics_fd = fds_named
+                    .get("metrics")
+                    .ok_or_else(|| anyhow::anyhow!("missing metrics socket fd"))?;
+
+                let std = unsafe { std::net::TcpListener::from_raw_fd(*metrics_fd) };
+                std.set_nonblocking(true)?;
+                tokio::net::TcpListener::from_std(std)?
+            };
+
             info!("Starting services");
 
-            let (proxy_fut, rpc_fut) = (
+            let (proxy_fut, rpc_fut, metrics_fut) = (
                 proxy::start(settings.clone(), state.clone(), tcp_listener),
                 rpc::start(settings.clone(), state.clone(), rpc_listener),
+                metrics::serve(settings.clone(), state.clone(), metrics_listener),
             );
 
             if let Err(e) = sd_notify_ready() {
@@ -324,7 +341,7 @@ async fn main() -> Result<()> {
 
             info!("Services are ready.");
 
-            tokio::try_join!(proxy_fut, rpc_fut)?;
+            tokio::try_join!(proxy_fut, rpc_fut, metrics_fut)?;
 
             info!("Exiting...");
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,62 @@
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http_body_util::Full;
+use hyper_util::rt::TokioIo;
+use prometheus::{register_int_gauge_vec, Encoder, IntGaugeVec, TextEncoder};
+use tokio::{net::TcpListener, sync::RwLock};
+
+use crate::{config::Settings, state::State};
+
+use hyper::{body::Incoming, service::service_fn, Request, Response};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    static ref PORTAIL_META: IntGaugeVec = register_int_gauge_vec!(
+        "portail_metadata",
+        "Metadata about deployed Portail such as version",
+        &["version"]
+    )
+    .unwrap();
+}
+
+async fn handle_request(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, hyper::Error> {
+    match (req.method(), req.uri().path()) {
+        (&hyper::Method::GET, "/metrics") => {
+            let mut buffer = Vec::new();
+            TextEncoder::new()
+                .encode(&prometheus::default_registry().gather(), &mut buffer)
+                .unwrap();
+            Ok(Response::builder()
+                .status(200)
+                .header("Content-Type", "text/plain")
+                .body(buffer.into())
+                .unwrap())
+        }
+        _ => Ok(Response::builder()
+            .status(404)
+            .body("Not Found".into())
+            .unwrap()),
+    }
+}
+
+pub async fn serve(
+    _settings: Arc<Settings>,
+    _state: Arc<RwLock<State>>,
+    listener: TcpListener,
+) -> anyhow::Result<()> {
+    PORTAIL_META
+        .with_label_values(&[env!("CARGO_PKG_VERSION")])
+        .set(1);
+    while let Ok((stream, _)) = listener.accept().await {
+        tokio::spawn(async move {
+            let http = hyper::server::conn::http1::Builder::new();
+            let conn = http.serve_connection(TokioIo::new(stream), service_fn(handle_request));
+            if let Err(e) = conn.await {
+                tracing::error!("HTTP error: {}", e);
+            }
+        });
+    }
+
+    Ok(())
+}

--- a/src/proxy/context.rs
+++ b/src/proxy/context.rs
@@ -1,5 +1,7 @@
 use std::{fmt::Display, net::SocketAddr};
 
+use tokio::time::Instant;
+
 #[allow(clippy::large_enum_variant)]
 pub enum InboundStream {
     TcpStream(tokio::net::TcpStream),
@@ -60,6 +62,7 @@ pub struct OwnedRequestContext {
     pub trace_id: uuid::Uuid,
     pub client_address: SocketAddr,
     pub acl_ctx: crate::acl::OwnedEvaluationContext,
+    pub creation_time: Instant,
 }
 
 #[derive(Debug, Clone)]
@@ -77,6 +80,7 @@ impl OwnedRequestContext {
             client_address,
             trace_id: uuid::Uuid::new_v4(),
             acl_ctx: crate::acl::OwnedEvaluationContext::empty(),
+            creation_time: Instant::now(),
         }
     }
 

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -2,6 +2,7 @@ use crate::acl::ACLRules;
 use crate::config::KnownBackend;
 use crate::proxy::context::{LocalRequestContext, OwnedRequestContext};
 use crate::proxy::protocol_detect::{ALPN_H2, ALPN_HTTP1_1};
+use crate::proxy::{ACL_EVALUATION_TIMES, DIRECT_EXIT_TOTAL, UPSTREAMS_HEALTH, UPSTREAMS_LATENCY};
 use crate::{
     config::{BackendSettings, Settings},
     proxy::{ProxyError, client_tls},
@@ -64,6 +65,10 @@ fn assess_request(
         }
     };
 
+    ACL_EVALUATION_TIMES
+        .with_label_values(&[assessment.action.to_label()])
+        .observe(start.elapsed().as_secs_f64());
+
     match assessment.action {
         // FIXME: render the deny template if there's one.
         crate::acl::Action::Deny(_explain_template) => {
@@ -72,6 +77,7 @@ fn assess_request(
                 duration_us = start.elapsed().as_micros(),
                 "Request denied by ACL",
             );
+
             let mut resp = Response::new(empty_body());
             *resp.status_mut() = StatusCode::FORBIDDEN;
 
@@ -333,6 +339,13 @@ async fn handle_http_request(
                 .await
                 {
                     Ok(Ok(upstream)) => {
+                        UPSTREAMS_LATENCY
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .observe(start.elapsed().as_secs_f64());
+                        UPSTREAMS_HEALTH
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .set(1);
+
                         info!(
                             subsystem = "proxy_access",
                             address = %final_address,
@@ -367,6 +380,9 @@ async fn handle_http_request(
                         }
                     }
                     Ok(Err(UpstreamConnectError::IO(err))) => {
+                        UPSTREAMS_HEALTH
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .set(0);
                         info!(
                             subsystem = "proxy_access",
                             backend = ?backend,
@@ -376,6 +392,9 @@ async fn handle_http_request(
                         );
                     }
                     Err(_) => {
+                        UPSTREAMS_HEALTH
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .set(0);
                         info!(
                             subsystem = "proxy_access",
                             backend = ?backend,
@@ -424,6 +443,7 @@ async fn handle_http_request(
                     duration_ms = start.elapsed().as_millis(),
                     "Stream directly established to final address (local exit)"
                 );
+                DIRECT_EXIT_TOTAL.with_label_values(&["http"]).inc();
                 stream = Some(Box::new(socket))
             }
             Ok(Err(e)) => warn!(

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -25,12 +25,84 @@ use http_connect::{serve_http1_connect, serve_http2_connect};
 use protocol_detect::{ALPN_H2, ALPN_HTTP1_1, DetectedProtocol, detect_protocol, detect_tls};
 use socks5::serve_socks5;
 
+use lazy_static::lazy_static;
+use prometheus::{
+    HistogramVec, IntCounterVec, IntGaugeVec, register_histogram_vec, register_int_counter_vec,
+    register_int_gauge_vec,
+};
+
+lazy_static! {
+    static ref TOTAL_CONNECTIONS: IntCounterVec = register_int_counter_vec!(
+        "portail_connections_total",
+        "Number of total connections received",
+        &["direction", "protocol"]
+    )
+    .unwrap();
+
+    /// An active connection is a connection that have its final upstream connected but is not
+    /// finished yet.
+    static ref ACTIVE_CONNECTIONS: IntGaugeVec = register_int_gauge_vec!(
+        "portail_active_connections",
+        "Number of active connections",
+        &["direction", "protocol"]
+    )
+    .unwrap();
+
+    static ref ERRORED_CONNECTIONS: IntCounterVec = register_int_counter_vec!(
+        "portail_connections_errors_total",
+        "Number of total connections that had errors",
+        &["error_type", "direction"]
+    )
+    .unwrap();
+
+    static ref DIRECT_EXIT_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "portail_direct_exit_total",
+        "Number of total direct exits performed",
+        &["protocol"]
+    ).unwrap();
+
+    static ref UPSTREAMS_HEALTH: IntGaugeVec = register_int_gauge_vec!(
+        "portail_upstream_up",
+        "Whether an upstream is up or not",
+        &["upstream"]
+    )
+    .unwrap();
+
+    static ref UPSTREAMS_LATENCY: HistogramVec = register_histogram_vec!(
+        "portail_upstream_latency_seconds",
+        "Latency to connect to one of the upstream",
+        &["upstream"]
+    )
+    .unwrap();
+
+    static ref ACL_EVALUATION_TIMES: HistogramVec = register_histogram_vec!(
+        "portail_acl_evaluation_seconds",
+        "Duration in seconds of ACL evaluations",
+        &["decision"]
+    )
+    .unwrap();
+}
+
 #[derive(Debug, Error)]
 enum ProxyError {
     #[error("SOCKS5 error: {0}")]
     SocksError(#[from] SocksError),
     #[error("HTTP CONNECT error: {0}")]
     HTTPConnectError(String),
+}
+
+macro_rules! count_errors {
+    ($expr:expr, $label:expr) => {
+        match $expr.await {
+            Ok(v) => Ok(v),
+            Err(e) => {
+                ERRORED_CONNECTIONS
+                    .with_label_values(&[$label, "ingress"])
+                    .inc();
+                Err(e)
+            }
+        }
+    };
 }
 
 async fn serve_authenticated_proxy(
@@ -44,15 +116,62 @@ async fn serve_authenticated_proxy(
     let (proto, stream) = detect_protocol(InboundStream::TlsStream(stream)).await?;
 
     if let InboundStream::TlsStream(stream) = stream {
+        TOTAL_CONNECTIONS
+            .with_label_values(&["ingress", proto.as_label()])
+            .inc();
+        let _guard = ActiveConnectionGuard::new("ingress", proto);
+
         match proto {
-            DetectedProtocol::Socks5 => serve_socks5(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http1 => serve_http1_connect(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http2 => serve_http2_connect(settings, state, ctx, stream).await?,
-            DetectedProtocol::Unknown => bail!("Unknown protocol"),
+            DetectedProtocol::Socks5 => {
+                count_errors!(serve_socks5(settings, state, ctx, stream), "socks5_error")?
+            }
+            DetectedProtocol::Http1 => count_errors!(
+                serve_http1_connect(settings, state, ctx, stream),
+                "http1_error"
+            )?,
+            DetectedProtocol::Http2 => count_errors!(
+                serve_http2_connect(settings, state, ctx, stream),
+                "http2_error"
+            )?,
+            DetectedProtocol::Unknown => {
+                ERRORED_CONNECTIONS
+                    .with_label_values(&["unsupported_proxy_protocol", "ingress"])
+                    .inc();
+                bail!("Unknown protocol")
+            }
         }
+
+        ACTIVE_CONNECTIONS
+            .with_label_values(&["ingress", proto.as_label()])
+            .dec();
     }
 
     Ok(())
+}
+
+struct ActiveConnectionGuard {
+    protocol: DetectedProtocol,
+    direction: &'static str,
+}
+
+impl ActiveConnectionGuard {
+    pub fn new(direction: &'static str, protocol: DetectedProtocol) -> Self {
+        ACTIVE_CONNECTIONS
+            .with_label_values(&[direction, protocol.as_label()])
+            .inc();
+        Self {
+            direction,
+            protocol,
+        }
+    }
+}
+
+impl Drop for ActiveConnectionGuard {
+    fn drop(&mut self) {
+        ACTIVE_CONNECTIONS
+            .with_label_values(&[self.direction, self.protocol.as_label()])
+            .dec();
+    }
 }
 
 async fn serve_unauthenticated_proxy(
@@ -62,12 +181,33 @@ async fn serve_unauthenticated_proxy(
     stream: tokio::net::TcpStream,
 ) -> anyhow::Result<()> {
     let (proto, stream) = detect_protocol(InboundStream::TcpStream(stream)).await?;
+
+    TOTAL_CONNECTIONS
+        .with_label_values(&["ingress", proto.as_label()])
+        .inc();
+
+    let _guard = ActiveConnectionGuard::new("ingress", proto);
+
     if let InboundStream::TcpStream(stream) = stream {
         match proto {
-            DetectedProtocol::Socks5 => serve_socks5(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http1 => serve_http1_connect(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http2 => serve_http2_connect(settings, state, ctx, stream).await?,
-            DetectedProtocol::Unknown => bail!("Unknown protocol"),
+            DetectedProtocol::Socks5 => {
+                count_errors!(serve_socks5(settings, state, ctx, stream), "socks5_error")?
+            }
+            DetectedProtocol::Http1 => count_errors!(
+                serve_http1_connect(settings, state, ctx, stream),
+                "http1_error"
+            )?,
+            DetectedProtocol::Http2 => count_errors!(
+                serve_http2_connect(settings, state, ctx, stream),
+                "http2_error"
+            )?,
+            DetectedProtocol::Unknown => {
+                ERRORED_CONNECTIONS
+                    .with_label_values(&["unsupported_proxy_protocol", "ingress"])
+                    .inc();
+
+                bail!("Unknown protocol")
+            }
         }
     }
 
@@ -152,10 +292,17 @@ pub async fn accept_client(
                                 }
                             }
                             Err(e) => {
+                                ERRORED_CONNECTIONS
+                                    .with_label_values(&["tls_handshake_failure", "ingress"])
+                                    .inc();
                                 error!(subsystem = "proxy_errors", "TLS handshake failed: {e:?}");
                             }
                         }
                     } else {
+                        ERRORED_CONNECTIONS
+                            .with_label_values(&["unsupported_tls", "ingress"])
+                            .inc();
+
                         error!(
                             subsystem = "proxy_errors",
                             "TLS received but no TLS configuration set in the proxy"
@@ -175,6 +322,10 @@ pub async fn accept_client(
                 }
 
                 Err(err) => {
+                    ERRORED_CONNECTIONS
+                        .with_label_values(&["malformed_tls", "ingress"])
+                        .inc();
+
                     error!(
                         subsystem = "proxy_errors",
                         "While detecting the header for TLS, error occurred: {err:?}"

--- a/src/proxy/protocol_detect.rs
+++ b/src/proxy/protocol_detect.rs
@@ -7,11 +7,23 @@ const H2_PREFACE: &[u8; 24] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
 pub const ALPN_H2: &[u8] = b"h2";
 pub const ALPN_HTTP1_1: &[u8] = b"http/1.1";
 
+#[derive(Debug, Clone, Copy)]
 pub enum DetectedProtocol {
     Socks5,
     Http1,
     Http2,
     Unknown,
+}
+
+impl DetectedProtocol {
+    pub fn as_label(&self) -> &'static str {
+        match self {
+            Self::Socks5 => "socks5",
+            Self::Http1 => "http1",
+            Self::Http2 => "http2",
+            _ => "unknown",
+        }
+    }
 }
 
 /// We use a different approach than `hyper-util` because we have access to the TLS session. We therefore use the following order to detect the protocol:

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -19,7 +19,10 @@ use tracing::{debug, info, warn};
 use crate::{
     acl::ACLRules,
     config::{BackendSettings, KnownBackend, Settings},
-    proxy::context::{LocalRequestContext, OwnedRequestContext, TargetContext},
+    proxy::{
+        ACL_EVALUATION_TIMES, DIRECT_EXIT_TOTAL, UPSTREAMS_HEALTH, UPSTREAMS_LATENCY,
+        context::{LocalRequestContext, OwnedRequestContext, TargetContext},
+    },
     state::State,
 };
 
@@ -51,6 +54,10 @@ fn assess_request(
             return Ok(Decision::TerminateWithError(ReplyError::GeneralFailure));
         }
     };
+
+    ACL_EVALUATION_TIMES
+        .with_label_values(&[assessment.action.to_label()])
+        .observe(start.elapsed().as_secs_f64());
 
     match assessment.action {
         // FIXME: render the deny template if there's one.
@@ -140,11 +147,11 @@ pub async fn route_to_backend<S: AsyncRead + Unpin + AsyncWrite>(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, fields(trace_id = %ctx.trace_id, client_address = %ctx.client_address, subsystem = "proxy_access"))]
+#[tracing::instrument(skip_all, fields(trace_id = %initial_ctx.trace_id, client_address = %initial_ctx.client_address, subsystem = "proxy_access"))]
 pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     opts: Arc<Settings>,
     state: Arc<RwLock<State>>,
-    ctx: OwnedRequestContext,
+    initial_ctx: OwnedRequestContext,
     socket: S,
 ) -> Result<(), SocksError> {
     let should_resolve_dns: bool = state.read().await.default_backend.is_none();
@@ -185,7 +192,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
 
     let (host, port) = target_context.initial_target.clone().into_string_and_port();
 
-    let mut ctx = ctx.as_local();
+    let mut ctx = initial_ctx.as_local();
     ctx.acl_ctx.insert(
         "proxy.protocol",
         crate::acl::ast::ConcreteOperand::String("socks5"),
@@ -325,6 +332,13 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                 .await
                 {
                     Ok(Ok(stream)) => {
+                        UPSTREAMS_LATENCY
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .observe(start.elapsed().as_secs_f64());
+                        UPSTREAMS_HEALTH
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .set(1);
+
                         debug!(
                             subsystem = "proxy_access",
                             backend = ?backend,
@@ -339,6 +353,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                         debug!(
                             subsystem = "proxy_access",
                             duration_ms = start.elapsed().as_millis(),
+                            total_duration_ms = initial_ctx.creation_time.elapsed().as_secs_f64(),
                             "SOCKS5 request finished"
                         );
 
@@ -346,6 +361,9 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                     }
 
                     Ok(Err(err)) => {
+                        UPSTREAMS_HEALTH
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .set(0);
                         debug!(
                             subsystem = "proxy_errors",
                             backend = ?backend,
@@ -356,6 +374,9 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                     }
 
                     Err(_) => {
+                        UPSTREAMS_HEALTH
+                            .with_label_values(&[backend.target_address.to_string()])
+                            .set(0);
                         debug!(
                             "Backend {} timed out after {:?}, trying the next one",
                             &backend.target_address, opts.request_timeout
@@ -421,8 +442,10 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         debug!(
             subsystem = "proxy_access",
             duration_ms = start.elapsed().as_millis(),
+            total_duration_ms = initial_ctx.creation_time.elapsed().as_secs_f64(),
             "SOCKS5 request finished"
         );
+        DIRECT_EXIT_TOTAL.with_label_values(&["socks5"]).inc();
     }
 
     Ok(())


### PR DESCRIPTION
This adds a set of simple yet interesting time series via the Prometheus metrics standard over ~~a UNIX domain socket (which many collectors know how to deal with)~~ TCP socket because Prometheus cannot deal with UDS.

TODO:

- ~~update nixos module~~
- ~~focus on a first set of metrics~~
- tests

Fixes #11.