### PR TITLE
nix/module: move to an attribute-set based config for ACL rules

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,7 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkEnableOption mkPackageOption mkOption types mkDefault concatStringsSep mkIf;
+  inherit (lib) mkEnableOption mkPackageOption mkOption types mkDefault concatStringsSep mkIf sort lessThan attrNames;
   cfg = config.services.portail;
 
   toml = pkgs.formats.toml { };
@@ -14,7 +14,12 @@ let
   in
   pkgs.writeTextFile {
     name = "portail-acl";
-    text = concatStringsSep "\n" cfg.acl.filter.rules;
+    text = 
+    let
+      sortedKeys = sort lessThan (attrNames cfg.acl.filter.rules);
+      sortedRules = map (key: cfg.acl.filter.rules.${key}) sortedKeys;
+    in
+    concatStringsSep "\n" sortedRules;
     checkPhase = ''
       echo checking ACL syntax...
       ${cfg.package}/bin/portail check-acl-syntax --config ${partialConfigFile} "$target"
@@ -45,11 +50,26 @@ in
       '';
 
       acl.filter.rules = mkOption {
-        type = types.listOf types.str;
-        default = [ ".* -> deny" ];
+        type = types.attrsOf types.str;
+        default = {
+          "99-default-deny" = ''
+            policy default_deny {
+              action deny
+            }
+          '';
+        };
+        example = {
+          "99-default-allow" = ''
+            policy default_allow {
+              action allow
+            }
+          '';
+        };
         description = ''
-          List of ACL filter rules.
-          By default, it denies all requests.
+          Attribute set of ACL filter rules.
+
+          Keys are used to sort the blocks of policies according to the lexicographical order.
+          This allows for easy extensibility and prioritization based on the attribute name keys lexicographical order.
         '';
       };
 

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -68,14 +68,13 @@ let
       enable = true;
       enableAtBoot = true;
       proxyListenStream = "0.0.0.0:8080";
-      acl.filter.rules = [
+      acl.filter.rules.default =
         ''
           policy hello {
             when host =~ "${allowedHostsRegex}"
             action allow
           }
-        ''
-      ];
+        '';
     };
   };
 
@@ -166,15 +165,14 @@ in
             # NOTE: we already possess part of the chain in the local trust store.
             tls-chain = certs.proxyCerts.${portailDomain}.cert;
           };
-          acl.filter.rules = [
+          acl.filter.rules.default =
             # DNS resolution takes place now here.
             ''
               policy hello {
                 when host =~ "192.168.1.1|hello.corp.example.com"
                 action allow
               }
-            ''
-          ];
+            '';
         };
       };
     };
@@ -330,14 +328,13 @@ in
               target-address = "192.168.1.50:8080";
             };
           };
-          acl.filter.rules = [
+          acl.filter.rules.default =
             ''
               policy hello {
                 when host =~ "hello.corp.example.com|192.168.1.1" and port == 80
                 action allow
               }
-            ''
-          ];
+            '';
         };
       };
     };
@@ -421,14 +418,13 @@ in
                 target-address = "${upstreamIp}:8080";
               };
             };
-            acl.filter.rules = [
+            acl.filter.rules.default =
               ''
                 policy hello {
                   when host =~ "hello.corp.example.com|192.168.1.1" and (port == 80 or port == 443)
                   action allow
                 }
-              ''
-            ];
+              '';
           };
         };
       };
@@ -514,14 +510,13 @@ in
             };
           };
 
-          acl.filter.rules = [
+          acl.filter.rules.default =
             ''
               policy hello {
                 when host == "hello.corp.example.com"
                 action allow
               }
-            ''
-          ];
+            '';
         };
       };
     };
@@ -726,14 +721,13 @@ in
             };
           };
 
-          acl.filter.rules = [
+          acl.filter.rules.default =
             ''
               policy hello {
                 when host =~ "hello.corp.example.com|192.168.1.1" and port == 80
                 action allow
               }
-            ''
-          ];
+            '';
         };
       };
     };


### PR DESCRIPTION
This avoids figuring out how to extend the start or the end of the rules and is a more proper delimitation, allowing for extension points.

Examples:

```nix
services.portail.acl.filter.rules."10-intranet" = "...";
# 01-cybersecurity will have priority over 10-intranet.
services.portail.acl.filter.rules."01-cybersecurity" = "...";
```