### PR TITLE
nix/tests/identity-aware: do not specify a timeout

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -634,12 +634,12 @@ in
 
         # The direct route is blocked, so the proxy cannot fallback.
         node.fail(
-          "curl --fail --max-time 5 https://hello.corp.example.com/"
+          "curl --fail https://hello.corp.example.com/"
         )
 
         # Test HTTP CONNECT curl -> portail -(TLS)-> portail (hop) -> corp-server
         result = json.loads(node.succeed(
-          "curl --fail --max-time 5 --proxy http://127.0.0.1:8080 https://hello.corp.example.com"
+          "curl --fail --proxy http://127.0.0.1:8080 https://hello.corp.example.com"
         ))
         assert (
           result['service'] == 'hello.corp'


### PR DESCRIPTION
GHA CI may be slower and we should leave a reasonable timeout.
Supersedes https://github.com/cloud-gouv/portail/pull/111 and https://github.com/cloud-gouv/portail/pull/119 attempts.