### PR TITLE
rpc: move socket a directory above

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -116,7 +116,7 @@ in
         socketConfig = {
           Service = "portail.service";
           Accept = "no";
-          ListenStream = "/run/portail/fr.gouv.portail.Control";
+          ListenStream = "/run/fr.gouv.portail.Control";
           PassCredentials = true;
           FileDescriptorName = "control";
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn get_default_config_path() -> PathBuf {
 }
 
 fn get_default_socket_path() -> PathBuf {
-    "/run/portail/fr.gouv.portail.Control".into()
+    "/run/fr.gouv.portail.Control".into()
 }
 
 #[derive(Subcommand)]


### PR DESCRIPTION
RuntimeDirectory=portail means that /run/portail is cleaned up every time systemctl restart portail.service is done.

Incremental updates of Portail would break the RPC layer if we leave it like this.

There's two solutions:

* RuntimeDirectoryPreserve=true
* move the RPC socket somewhere else

The latter seems better because the RuntimeDirectory is *runtime* and the RPC socket should live forever independently of the actual operational state of portail.service.