### PR TITLE
proxy/{http,socks5}: revalidate `route.local` and transfer client errors

### DIFF
--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -310,7 +310,7 @@ async fn handle_http_request(
                 .await
                 {
                     Ok(Ok(upstream)) => {
-                        debug!(
+                        info!(
                             subsystem = "proxy_access",
                             address = %final_address,
                             backend = ?backend,
@@ -354,7 +354,7 @@ async fn handle_http_request(
         let start = Instant::now();
         match timeout(settings.request_timeout, TcpStream::connect(&final_address)).await {
             Ok(Ok(socket)) => {
-                debug!(
+                info!(
                     subsystem = "proxy_access",
                     address = %final_address,
                     duration_ms = start.elapsed().as_millis(),

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -1,5 +1,6 @@
+use crate::acl::ACLRules;
 use crate::config::KnownBackend;
-use crate::proxy::context::OwnedRequestContext;
+use crate::proxy::context::{LocalRequestContext, OwnedRequestContext};
 use crate::proxy::protocol_detect::{ALPN_H2, ALPN_HTTP1_1};
 use crate::{
     config::{BackendSettings, Settings},
@@ -7,6 +8,7 @@ use crate::{
     state::State,
 };
 use bytes::Bytes;
+use http::uri::Authority;
 use http_body_util::{BodyExt, Empty, combinators::BoxBody};
 use hyper::{
     Method, Request, Response, StatusCode,
@@ -18,6 +20,7 @@ use hyper::{
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use std::io;
 use std::sync::Arc;
+use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::RwLock;
@@ -34,6 +37,59 @@ type OutboundStream = Box<dyn OutboundStreamIo + Send + Unpin>;
 enum InboundHttpProtocol {
     Http1,
     Http2,
+}
+
+enum Decision {
+    TerminateWithResponse(Response<BoxBody<Bytes, hyper::Error>>),
+    RedirectDestination(String),
+    Continue,
+}
+
+fn assess_request(
+    start: Instant,
+    target_authority: &Authority,
+    ctx: &LocalRequestContext<'_>,
+    acl: &ACLRules,
+) -> Result<Decision, hyper::Error> {
+    let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
+        Ok(assessment) => assessment,
+        Err(failure) => {
+            let mut resp = Response::new(empty_body());
+            warn!(
+                subsystem = "proxy_errors",
+                "Failed to evaluate a request: {} (Context: {:#?})", failure, ctx
+            );
+            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            return Ok(Decision::TerminateWithResponse(resp));
+        }
+    };
+
+    match assessment.action {
+        // FIXME: render the deny template if there's one.
+        crate::acl::Action::Deny(_explain_template) => {
+            info!(
+                subsystem = "proxy_access",
+                duration_us = start.elapsed().as_micros(),
+                "Request denied by ACL",
+            );
+            let mut resp = Response::new(empty_body());
+            *resp.status_mut() = StatusCode::FORBIDDEN;
+
+            Ok(Decision::TerminateWithResponse(resp))
+        }
+        crate::acl::Action::Redirect(target) => {
+            info!(
+                subsystem = "proxy_access",
+                original_host = %target_authority.host(),
+                redirected_to = %target,
+                duration_us = start.elapsed().as_micros(),
+                "Request redirected by ACL",
+            );
+            Ok(Decision::RedirectDestination(target.to_string()))
+        }
+
+        _ => Ok(Decision::Continue),
+    }
 }
 
 /// References:
@@ -233,43 +289,10 @@ async fn handle_http_request(
         );
     }
 
-    let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
-        Ok(assessment) => assessment,
-        Err(failure) => {
-            let mut resp = Response::new(empty_body());
-            warn!(
-                subsystem = "proxy_errors",
-                "Failed to evaluate a request: {} (Context: {:#?})", failure, ctx
-            );
-            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-            return Ok(resp);
-        }
-    };
-
-    match assessment.action {
-        // FIXME: render the deny template if there's one.
-        crate::acl::Action::Deny(_explain_template) => {
-            info!(
-                subsystem = "proxy_access",
-                duration_us = start.elapsed().as_micros(),
-                "Request denied by ACL",
-            );
-            let mut resp = Response::new(empty_body());
-            *resp.status_mut() = StatusCode::FORBIDDEN;
-            return Ok(resp);
-        }
-        crate::acl::Action::Redirect(target) => {
-            info!(
-                subsystem = "proxy_access",
-                original_host = %target_authority.host(),
-                redirected_to = %target,
-                duration_us = start.elapsed().as_micros(),
-                "Request redirected by ACL",
-            );
-            final_address = target.to_string();
-        }
-
-        _ => {}
+    match assess_request(start, target_authority, &ctx, acl)? {
+        Decision::TerminateWithResponse(resp) => return Ok(resp),
+        Decision::RedirectDestination(target) => final_address = target,
+        Decision::Continue => {}
     }
 
     info!(
@@ -343,7 +366,26 @@ async fn handle_http_request(
             }
         }
     }
+
     if stream.is_none() {
+        // At this point, we need to re-assess if the request can go through.
+        ctx.acl_ctx.insert(
+            "route.local",
+            crate::acl::ast::ConcreteOperand::Boolean(true),
+        );
+
+        match assess_request(start, target_authority, &ctx, acl)? {
+            Decision::TerminateWithResponse(resp) => return Ok(resp),
+            Decision::RedirectDestination(target) => final_address = target,
+            _ => {}
+        }
+
+        info!(
+            subsystem = "proxy_access",
+            duration_us = start.elapsed().as_micros(),
+            "Request allowed by ACL (direct exit context)",
+        );
+
         debug!(
             subsystem = "proxy_access",
             address = %final_address,

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -477,6 +477,14 @@ fn empty_body() -> BoxBody<Bytes, hyper::Error> {
         .boxed()
 }
 
+#[derive(Debug, Error)]
+pub enum UpstreamConnectError {
+    #[error("An IO error occurred: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("The upstream response contains an error")]
+    UpstreamResponse(hyper::Response<Incoming>),
+}
+
 /// Send CONNECT and return the stream on 2xx response
 /// Ref: https://github.com/hyperium/hyper/blob/master/examples/client.rs
 ///
@@ -490,7 +498,7 @@ async fn connect_to_http_proxy_backend(
     final_address: &str,
     state: Arc<RwLock<State>>,
     inbound_protocol: &InboundHttpProtocol,
-) -> io::Result<OutboundStream> {
+) -> Result<OutboundStream, UpstreamConnectError> {
     let socket = TcpStream::connect(backend.target_address).await?;
 
     let (stream, use_http2): (OutboundStream, bool) = if backend.identity_aware {
@@ -556,13 +564,7 @@ async fn connect_to_http_proxy_backend(
             .map_err(io::Error::other)?;
 
         if !response.status().is_success() {
-            return Err(io::Error::new(
-                io::ErrorKind::ConnectionRefused,
-                format!(
-                    "HTTP proxy CONNECT failed with status {}",
-                    response.status()
-                ),
-            ));
+            return Err(UpstreamConnectError::UpstreamResponse(response));
         }
 
         let upgraded = hyper::upgrade::on(&mut response)
@@ -592,13 +594,7 @@ async fn connect_to_http_proxy_backend(
             .map_err(io::Error::other)?;
 
         if !response.status().is_success() {
-            return Err(io::Error::new(
-                io::ErrorKind::ConnectionRefused,
-                format!(
-                    "HTTP proxy CONNECT failed with status {}",
-                    response.status()
-                ),
-            ));
+            return Err(UpstreamConnectError::UpstreamResponse(response));
         }
 
         let upgraded = hyper::upgrade::on(&mut response)

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -344,8 +344,30 @@ async fn handle_http_request(
                         stream = Some(upstream);
                         break;
                     }
-                    Ok(Err(err)) => {
-                        debug!(
+                    Ok(Err(UpstreamConnectError::UpstreamResponse(resp))) => {
+                        // Send back the client errors.
+                        if resp.status().is_client_error() {
+                            info!(
+                                subsystem = "proxy_access",
+                                backend = ?backend,
+                                duration_ms = start.elapsed().as_millis(),
+                                status = %resp.status(),
+                                "Backend returned a non-200 client error for HTTP CONNECT, returning it to the client and terminating the request"
+                            );
+
+                            return Ok(resp.map(|b| b.boxed()));
+                        } else {
+                            info!(
+                                subsystem = "proxy_access",
+                                backend = ?backend,
+                                duration_ms = start.elapsed().as_millis(),
+                                status = %resp.status(),
+                                "Backend returned a non-200 response for HTTP CONNECT, trying next as it's not a client error"
+                            );
+                        }
+                    }
+                    Ok(Err(UpstreamConnectError::IO(err))) => {
+                        info!(
                             subsystem = "proxy_access",
                             backend = ?backend,
                             duration_ms = start.elapsed().as_millis(),
@@ -354,7 +376,7 @@ async fn handle_http_request(
                         );
                     }
                     Err(_) => {
-                        debug!(
+                        info!(
                             subsystem = "proxy_access",
                             backend = ?backend,
                             duration_ms = start.elapsed().as_millis(),

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -17,8 +17,9 @@ use tokio_rustls::TlsStream;
 use tracing::{debug, info, warn};
 
 use crate::{
+    acl::ACLRules,
     config::{BackendSettings, KnownBackend, Settings},
-    proxy::context::{OwnedRequestContext, TargetContext},
+    proxy::context::{LocalRequestContext, OwnedRequestContext, TargetContext},
     state::State,
 };
 
@@ -26,6 +27,67 @@ use crate::{
 pub enum OutboundSock5Stream {
     Tls(Socks5Stream<TlsStream<TcpStream>>),
     Plain(Socks5Stream<TcpStream>),
+}
+
+enum Decision {
+    TerminateWithError(ReplyError),
+    RedirectDestination(TargetAddr),
+    Continue,
+}
+
+fn assess_request(
+    start: Instant,
+    target_context: &TargetContext,
+    ctx: &LocalRequestContext<'_>,
+    acl: &ACLRules,
+) -> Result<Decision, fast_socks5::SocksError> {
+    let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
+        Ok(assessment) => assessment,
+        Err(failure) => {
+            warn!(
+                subsystem = "proxy_errors",
+                "Failed to evaluate a request: {} (Context: {:#?})", failure, ctx
+            );
+            return Ok(Decision::TerminateWithError(ReplyError::GeneralFailure));
+        }
+    };
+
+    match assessment.action {
+        // FIXME: render the deny template if there's one.
+        crate::acl::Action::Deny(_explain_template) => {
+            info!(
+                subsystem = "proxy_access",
+                target_context = ?target_context,
+                duration_us = start.elapsed().as_micros(),
+                "SOCKS5 request blocked due to ACL"
+            );
+
+            Ok(Decision::TerminateWithError(
+                ReplyError::ConnectionNotAllowed,
+            ))
+        }
+        crate::acl::Action::Redirect(target) => {
+            info!(
+                subsystem = "proxy_access",
+                target_context = ?target_context,
+                redirected_to = %target,
+                duration_us = start.elapsed().as_micros(),
+                "SOCKS5 request redirected due to ACL"
+            );
+
+            Ok(Decision::RedirectDestination(TargetAddr::Domain(
+                target
+                    .host()
+                    .expect("BUG: Redirect target should be an FQDN")
+                    .to_owned(),
+                // FIXME: calculation of the default port should be better and take into account
+                // the scheme.
+                target.port_u16().unwrap_or(80),
+            )))
+        }
+
+        _ => Ok(Decision::Continue),
+    }
 }
 
 pub async fn connect_to_backend(
@@ -222,50 +284,13 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         );
     }
 
-    let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
-        Ok(assessment) => assessment,
-        Err(failure) => {
-            proto.reply_error(&ReplyError::GeneralFailure).await?;
-            warn!(
-                subsystem = "proxy_errors",
-                "Failed to evaluate a request: {} (Context: {:#?})", failure, ctx
-            );
+    match assess_request(start, &target_context, &ctx, acl)? {
+        Decision::TerminateWithError(error) => {
+            proto.reply_error(&error).await?;
             return Ok(());
         }
-    };
-
-    match assessment.action {
-        // FIXME: render the deny template if there's one.
-        crate::acl::Action::Deny(_explain_template) => {
-            info!(
-                subsystem = "proxy_access",
-                target_context = ?target_context,
-                duration_us = start.elapsed().as_micros(),
-                "SOCKS5 request blocked due to ACL"
-            );
-            proto.reply_error(&ReplyError::ConnectionNotAllowed).await?;
-            return Ok(());
-        }
-        crate::acl::Action::Redirect(target) => {
-            info!(
-                subsystem = "proxy_access",
-                target_context = ?target_context,
-                redirected_to = %target,
-                duration_us = start.elapsed().as_micros(),
-                "SOCKS5 request redirected due to ACL"
-            );
-            final_addr = TargetAddr::Domain(
-                target
-                    .host()
-                    .expect("BUG: Redirect target should be an FQDN")
-                    .to_owned(),
-                // FIXME: calculation of the default port should be better and take into account
-                // the scheme.
-                target.port_u16().unwrap_or(80),
-            );
-        }
-
-        _ => {}
+        Decision::RedirectDestination(tgt_addr) => final_addr = tgt_addr,
+        Decision::Continue => {}
     }
 
     info!(
@@ -349,6 +374,28 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
             duration_ms = start.elapsed().as_millis(),
             "No backend, terminating the connection ourself"
         );
+
+        let start = Instant::now();
+
+        ctx.acl_ctx.insert(
+            "route.local",
+            crate::acl::ast::ConcreteOperand::Boolean(true),
+        );
+        match assess_request(start, &target_context, &ctx, acl)? {
+            Decision::TerminateWithError(error) => {
+                proto.reply_error(&error).await?;
+                return Ok(());
+            }
+            Decision::RedirectDestination(tgt_addr) => final_addr = tgt_addr,
+            Decision::Continue => {}
+        }
+
+        info!(
+            subsystem = "proxy_access",
+            duration_us = start.elapsed().as_micros(),
+            "SOCKS5 request allowed due to ACL (direct exit)"
+        );
+
         let start = Instant::now();
         match (cmd, opts.public_address) {
             (Socks5Command::TCPConnect, _) => {


### PR DESCRIPTION
Historically, we have been checking `route.local` based on a reasonable heuristic which is to have no backend to route to. It is also possible we have backends to route to but they all fail for some reason and we fallback to direct exit effectively.

To avoid having a complicated security model, we close this possibility and align expected behaviors at the cost of an extra evaluation assessment (which is fast enough).

Additionally, all HTTP client errors from upstreams are transferred back. Only server errors or others weird errors are considered to be internal and will trigger the failover process.

Signed-off-by: Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>