### PR TITLE
feat: add in-process DNS resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +386,16 @@ dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -427,6 +447,12 @@ dependencies = [
  "cast",
  "itertools",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -503,12 +529,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -603,6 +646,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -764,6 +816,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand",
+ "ring",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,10 +991,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -910,6 +1135,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +1176,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
@@ -968,6 +1264,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1020,6 +1322,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1386,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1112,6 +1441,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -1168,6 +1503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+
+[[package]]
 name = "portail"
 version = "0.1.0"
 dependencies = [
@@ -1177,6 +1518,7 @@ dependencies = [
  "clap",
  "criterion",
  "fast-socks5",
+ "hickory-resolver",
  "http",
  "http-body-util",
  "hyper",
@@ -1202,10 +1544,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1327,6 +1689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1706,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -1439,6 +1816,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1550,6 +1933,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1985,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "strsim"
@@ -1626,6 +2031,44 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -1717,6 +2160,16 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1960,6 +2413,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2610,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -2250,6 +2738,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2270,10 +2787,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zlink"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -663,12 +663,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -676,6 +692,17 @@ name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -725,9 +752,13 @@ version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1518,6 +1549,7 @@ dependencies = [
  "clap",
  "criterion",
  "fast-socks5",
+ "futures",
  "hickory-resolver",
  "http",
  "http-body-util",
@@ -1534,6 +1566,7 @@ dependencies = [
  "thiserror 2.0.19",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ zlink = "^0.7"
 rustls-pki-types = "^1"
 uuid = { version = "^1", features = ["v4"] }
 tracing-appender = "0.2.5"
+hickory-resolver = { version = "^0.26", features = ["tokio"] }
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ rustls-pki-types = "^1"
 uuid = { version = "^1", features = ["v4"] }
 tracing-appender = "0.2.5"
 hickory-resolver = { version = "^0.26", features = ["tokio"] }
+futures = "0.3.33"
+tokio-util = "0.7.19"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -96,6 +96,7 @@ in
       filter-acl-rules-path = aclRulesFilePath;
       request-timeout = mkDefault 30;
       tcp-nodelay = mkDefault false;
+      dns.timeout = mkDefault 5;
     };
 
     systemd.sockets = {

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -901,4 +901,131 @@ in
       ), "Unexpected result from the web service: {}".format(json.dumps(result))
     '';
   };
+
+  # Tests in-process DNS resolution.
+  dns-resolver =
+    let
+      dnsServerIp = "192.168.1.10";
+      corpServerIp = "192.168.1.200";
+      nodeIp = "192.168.1.100";
+    in
+    pkgs.testers.nixosTest {
+      name = "dns-resolver";
+      nodes = {
+        corp-server = mkServiceNode { };
+
+        dns-server = {
+          networking.interfaces.eth1.ipv4.addresses = [
+            {
+              address = dnsServerIp;
+              prefixLength = 24;
+            }
+          ];
+
+          networking.firewall.allowedUDPPorts = [ 53 ];
+
+          services.dnsmasq = {
+            enable = true;
+            #resolveLocalQueries = false;
+            settings = {
+              #interface = [ "eth1" ];
+              #bind-interfaces = true;
+              listen-address = [ dnsServerIp ];
+              address = [ "/${helloDomain}/${corpServerIp}" ];
+            };
+          };
+        };
+
+        node = { ... }: {
+          imports = [ ../module.nix portailEnv ];
+
+          # No networking.hosts entries.
+
+          networking.interfaces.eth1.ipv4.addresses = [
+            {
+              address = nodeIp;
+              prefixLength = 24;
+            }
+          ];
+
+          networking.firewall.allowedTCPPorts = [ 8080 ];
+
+          environment.systemPackages = [ pkgs.dnsutils ];
+
+          services.portail = {
+            enable = true;
+            enableAtBoot = true;
+            proxyListenStream = "0.0.0.0:8080";
+            settings.dns.resolvers = [ dnsServerIp ];
+            acl.filter.rules.default =
+              ''
+                policy hello {
+                  when host == "${helloDomain}"
+                  action allow
+                }
+              '';
+          };
+        };
+      };
+
+      testScript = ''
+        import json
+
+        hello_host = "${helloDomain}"
+        dns_server_ip = "${dnsServerIp}"
+        corp_server_ip = "${corpServerIp}"
+        self_ip = "${nodeIp}"
+
+        start_all()
+
+        # Wait for the server to be ready.
+        corp_server.wait_for_unit("multi-user.target")
+
+        # Wait for NGINX to be ready.
+        corp_server.wait_for_unit("nginx.service")
+        corp_server.wait_for_open_port(80)
+
+        # Wait for dnsmasq to be ready.
+        dns_server.wait_for_unit("multi-user.target")
+        dns_server.wait_for_unit("dnsmasq.service")
+
+        # Wait for portail to be ready.
+        node.wait_for_unit("multi-user.target")
+        node.wait_for_unit("portail.service")
+        node.wait_for_open_port(8080)
+
+        # ${helloDomain} is not in /etc/hosts on the portail node.
+        node.fail(f"getent ahostsv4 {hello_host}")
+
+        # The DNS server resolves the name.
+        resolved_ip = node.succeed(f"dig @{dns_server_ip} {hello_host} +short +time=2").strip()
+        assert resolved_ip == corp_server_ip, f"expected {corp_server_ip}, got {resolved_ip!r}"
+
+        # URL is not resolved by the system resolver.
+        node.fail(
+          f"curl --fail --socks5 127.0.0.1:8080 http://{hello_host}"
+        )
+
+        # Test in-process DNS resolution for SOCKS5.
+        result = json.loads(node.succeed(
+          f"curl --fail --socks5-hostname 127.0.0.1:8080 http://{hello_host}"
+        ))
+        assert (
+          result['service'] == 'hello.corp'
+          and result['remote_addr'] == self_ip
+          and result['protocol'] == 'HTTP/1.1'
+        ), "Unexpected SOCKS5 result: {}".format(json.dumps(result))
+
+        # Test in-process DNS resolution for HTTP CONNECT.
+        result = json.loads(node.succeed(
+          f"curl --fail --proxytunnel --proxy http://127.0.0.1:8080 http://{hello_host}"
+        ))
+        assert (
+          result['service'] == 'hello.corp'
+          and result['remote_addr'] == self_ip
+          and not result['tls']
+          and result['protocol'] == 'HTTP/1.1'
+        ), "Unexpected HTTP CONNECT result: {}".format(json.dumps(result))
+      '';
+    };
 }

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -926,10 +926,7 @@ in
 
           services.dnsmasq = {
             enable = true;
-            #resolveLocalQueries = false;
             settings = {
-              #interface = [ "eth1" ];
-              #bind-interfaces = true;
               listen-address = [ dnsServerIp ];
               address = [ "/${helloDomain}/${corpServerIp}" ];
             };

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,34 @@ pub struct RPCSettings {
     pub trusted_groups: Vec<String>,
 }
 
+fn default_dns_timeout() -> Duration {
+    Duration::from_secs(5)
+}
+
+#[serde_with::serde_as]
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DnsSettings {
+    /// Resolvers for direct-exit name resolution.
+    /// When empty, the system resolver is used instead.
+    #[serde(default)]
+    pub resolvers: Vec<std::net::IpAddr>,
+
+    /// Timeout for DNS lookups.
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    #[serde(default = "default_dns_timeout")]
+    pub timeout: Duration,
+}
+
+impl Default for DnsSettings {
+    fn default() -> Self {
+        Self {
+            resolvers: Vec::new(),
+            timeout: default_dns_timeout(),
+        }
+    }
+}
+
 #[serde_with::serde_as]
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -165,6 +193,10 @@ pub struct Settings {
 
     /// Whether to set a default upstream.
     pub default_backend: Option<String>,
+
+    /// DNS settings for direct-exit name resolution.
+    #[serde(default)]
+    pub dns: DnsSettings,
 
     /// List of backends to which we can route proxy queries.
     #[serde(default)]

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+use std::{net::IpAddr, time::Duration};
+
+use hickory_resolver::{
+    TokioResolver,
+    config::{LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts},
+    net::NetError,
+    net::runtime::TokioRuntimeProvider,
+};
+use thiserror::Error;
+use tokio::{net::lookup_host, time::timeout};
+
+use crate::config::DnsSettings;
+
+#[derive(Debug, Error)]
+pub enum DnsError {
+    #[error("dns lookup failed for {host}")]
+    LookupFailed {
+        host: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("no dns records for {host}")]
+    NoRecords { host: String },
+
+    #[error("dns lookup timed out for {host}")]
+    TimedOut { host: String },
+}
+
+pub struct DnsResolver {
+    hickory: Option<TokioResolver>,
+    timeout: Duration,
+}
+
+/// If DNS settings are provided, uses Hickory DNS resolver. Otherwise, uses the system resolver.
+impl DnsResolver {
+    pub fn from_settings(dns: &DnsSettings) -> anyhow::Result<Arc<Self>> {
+        let hickory = if dns.resolvers.is_empty() {
+            None
+        } else {
+            Some(build_hickory(&dns.resolvers, dns.timeout)?)
+        };
+
+        Ok(Arc::new(Self {
+            hickory,
+            timeout: dns.timeout,
+        }))
+    }
+
+    pub async fn lookup(&self, host: &str) -> Result<Vec<IpAddr>, DnsError> {
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return Ok(vec![ip]);
+        }
+
+        let ips: Vec<IpAddr> = if let Some(resolver) = &self.hickory {
+            let lookup = resolver.lookup_ip(host).await.map_err(|err| match err {
+                NetError::Timeout => DnsError::TimedOut {
+                    host: host.to_owned(),
+                },
+                _ => DnsError::LookupFailed {
+                    host: host.to_owned(),
+                    source: std::io::Error::other(err),
+                },
+            })?;
+            lookup.iter().collect()
+        } else {
+            // lookup_host is a wrapper around std::net::ToSocketAddrs (which is just getaddrinfo):
+            // https://github.com/tokio-rs/tokio/blob/d87569164fb61145e79e7ffe0b25783569cc8f93/tokio/src/net/lookup_host.rs#L32
+            //
+            // It is used to resolve addresses by both fast-socks5 and tokio:
+            // https://github.com/dizda/fast-socks5/blob/acb847616ec44b6c2d6cdaddeba090d18c6c5d5c/src/util/target_addr.rs#L61
+            // https://github.com/tokio-rs/tokio/blob/d87569164fb61145e79e7ffe0b25783569cc8f93/tokio/src/net/tcp/stream.rs#L119
+            timeout(self.timeout, lookup_host((host, 0)))
+                .await
+                .map_err(|_| DnsError::TimedOut {
+                    host: host.to_owned(),
+                })?
+                .map_err(|source| DnsError::LookupFailed {
+                    host: host.to_owned(),
+                    source,
+                })?
+                .map(|addr| addr.ip())
+                .collect()
+        };
+
+        if ips.is_empty() {
+            return Err(DnsError::NoRecords {
+                host: host.to_owned(),
+            });
+        }
+
+        Ok(ips)
+    }
+}
+
+fn build_hickory(servers: &[IpAddr], timeout: Duration) -> anyhow::Result<TokioResolver> {
+    let name_servers: Vec<NameServerConfig> = servers
+        .iter()
+        .copied()
+        .map(NameServerConfig::udp_and_tcp)
+        .collect();
+    let config = ResolverConfig::from_parts(None, vec![], name_servers);
+
+    let mut opts = ResolverOpts::default();
+    opts.timeout = timeout;
+    // Default is Ipv6AndIpv4:
+    // https://docs.rs/hickory-resolver/0.26.1/src/hickory_resolver/config.rs.html#709
+    opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+
+    TokioResolver::builder_with_config(config, TokioRuntimeProvider::default())
+        .with_options(opts)
+        .build()
+        .map_err(|err| anyhow::anyhow!("failed to build DNS resolver: {err}"))
+}

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,14 +1,18 @@
+use std::cmp::Ordering::Equal;
+use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::{net::IpAddr, time::Duration};
 
+use futures::future::select_ok;
 use hickory_resolver::{
     TokioResolver,
-    config::{LookupIpStrategy, NameServerConfig, ResolverConfig, ResolverOpts},
+    config::{NameServerConfig, ResolverConfig, ResolverOpts},
     net::NetError,
     net::runtime::TokioRuntimeProvider,
 };
 use thiserror::Error;
-use tokio::{net::lookup_host, time::timeout};
+use tokio::{net::TcpStream, net::lookup_host, time::timeout};
 
 use crate::config::DnsSettings;
 
@@ -94,6 +98,276 @@ impl DnsResolver {
     }
 }
 
+/// Happy Eyeballs v2 constants per RFC 8305.
+/// Minimum delay between successive connection attempts within the same address
+/// family, to avoid flooding the network stack with SYNs to unreachable hosts.
+const CONNECTION_ATTEMPT_DELAY: Duration = Duration::from_millis(250);
+
+#[derive(Debug, Error)]
+pub enum HappyEyeballsError {
+    #[error("DNS resolution failed: {0}")]
+    Dns(#[from] DnsError),
+
+    #[error("all connection attempts to {host}:{port} failed")]
+    AllFailed { host: String, port: u16 },
+
+    #[error("no addresses to connect to for {host}:{port}")]
+    /// No addresses were available for the hostname.
+    #[allow(dead_code)]
+    NoAddresses { host: String, port: u16 },
+}
+
+/// Resolves `host` to addresses, then races IPv6 and IPv4 connection attempts
+/// per RFC 8305 (Happy Eyeballs v2).
+///
+/// Returns the first successfully established `TcpStream` together with the
+/// remote `SocketAddr` it connected to.
+pub async fn happy_eyeballs_connect(
+    resolver: &DnsResolver,
+    host: &str,
+    port: u16,
+    connect_timeout: Duration,
+    tcp_nodelay: bool,
+) -> Result<(TcpStream, SocketAddr), HappyEyeballsError> {
+    let ips = resolver.lookup(host).await?;
+    let (stream, addr) = happy_eyeballs_connect_addrs(ips, port, connect_timeout)
+        .await
+        .map_err(|_| HappyEyeballsError::AllFailed {
+            host: host.to_owned(),
+            port,
+        })?;
+    if tcp_nodelay {
+        // Best-effort: nodelay failure should not fail the connection.
+        let _ = stream.set_nodelay(true);
+    }
+    Ok((stream, addr))
+}
+
+/// Core Happy Eyeballs v2 algorithm: given already-resolved addresses, race
+/// connection attempts across address families.
+///
+/// This is separated from [`happy_eyeballs_connect`] so it can be tested
+/// without a DNS resolver.
+async fn happy_eyeballs_connect_addrs(
+    // TODO: make this a stream later on once hickory supports it.
+    addrs: Vec<IpAddr>,
+    port: u16,
+    connect_timeout: Duration,
+) -> Result<(TcpStream, SocketAddr), Vec<io::Error>> {
+    if addrs.is_empty() {
+        return Err(vec![]);
+    }
+
+    let addrs = sort_destinations(addrs, AddressFamilyPreference::Ipv6First);
+
+    // TODO: obtain temporary RTTs information on regular targets in-memory to better influence
+    // destination selection.
+
+    // Each task sends its success here. First one wins.
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<io::Result<(TcpStream, SocketAddr)>>(1);
+
+    let handle = tokio::spawn(try_connect_family(addrs, port, connect_timeout, tx));
+
+    // Wait for the first successful connection.
+    let result = match rx.recv().await {
+        Some(Ok((stream, addr))) => Ok((stream, addr)),
+        Some(Err(_)) => match rx.recv().await {
+            Some(Ok((stream, addr))) => Ok((stream, addr)),
+            _ => Err(vec![]),
+        },
+        None => Err(vec![]),
+    };
+
+    // Cancel the losing task(s).
+    handle.abort();
+
+    result
+}
+
+/// Try connecting to each address in `addrs` sequentially.
+///
+/// Sends the first successful `(TcpStream, SocketAddr)` through `tx` and
+/// returns. If all addresses fail, the function returns silently.
+///
+/// The first attempt begins after `initial_delay`. Subsequent attempts within
+/// the family are spaced by [`CONNECTION_ATTEMPT_DELAY`].
+async fn try_connect_family(
+    addrs: Vec<IpAddr>,
+    port: u16,
+    connect_timeout: Duration,
+    tx: tokio::sync::mpsc::Sender<io::Result<(TcpStream, SocketAddr)>>,
+) {
+    if addrs.is_empty() {
+        return;
+    }
+
+    let cancel_handle = tokio_util::sync::CancellationToken::new();
+
+    let connect_futures: Vec<_> = addrs
+        .into_iter()
+        .enumerate()
+        .map(|(i, ip)| {
+            let addr = SocketAddr::new(ip, port);
+            let cancel_handle = cancel_handle.clone();
+            async move {
+                // Stagger the start of each connection attempt, the first one gets zero
+                // staggering.
+                tokio::select! {
+                    _ = tokio::time::sleep(CONNECTION_ATTEMPT_DELAY * i as u32) => {},
+                    _ = cancel_handle.cancelled() => {
+                        return Err(io::Error::new(io::ErrorKind::ConnectionAborted, "cancelled due to prior success"));
+                    }
+                }
+
+                tokio::select! {
+                    result = timeout(connect_timeout, TcpStream::connect(addr)) => {
+                        match result {
+                            Ok(Ok(stream)) => {
+                                // Success! Signal cancellation to all other tasks
+                                cancel_handle.cancel();
+                                Ok((stream, addr))
+                            }
+                            Ok(Err(e)) => Err(e),
+                            Err(_) => Err(io::Error::new(io::ErrorKind::TimedOut, "timeout")),
+                        }
+                    }
+
+                    _ = cancel_handle.cancelled() => {
+                        // Cancelled during connection attempt
+                        Err(io::Error::new(io::ErrorKind::ConnectionAborted, "cancelled due to prior success"))
+                    }
+                }
+            }
+        })
+        .collect();
+
+    // `select_ok` requires pinned futures.
+    let pinned_futures: Vec<_> = connect_futures.into_iter().map(Box::pin).collect();
+
+    // Race all connections, get the first successful one
+    match select_ok(pinned_futures).await {
+        Ok(((stream, addr), _index)) => {
+            let _ = tx.send(Ok((stream, addr))).await;
+        }
+        Err(_) => {
+            // All connections failed.
+        }
+    }
+
+    // All addresses failed. The sender is dropped implicitly.
+    // If this was the last sender, the receiver will be disconnected.
+}
+
+#[derive(Debug, Clone, Copy)]
+enum AddressFamilyPreference {
+    Ipv6First,
+    #[allow(dead_code)]
+    Ipv4First,
+}
+
+/// Sort destination addresses per RFC 6724 §6, then interleave families one-by-one so connection
+/// attempts alternate between address families.
+///
+/// # Algorithm
+///
+/// 1. Split addresses into 2 families groups.
+/// 2. Sort each group independently per RFC 6724 rules.
+/// 3. Interleave starting with the preferred family: `pref[0], other[0], pref[1], other[1], …`.
+///
+/// This gives a head start to preferred family (to `CONNECTION_ATTEMPT_DELAY`).
+fn sort_destinations(addrs: Vec<IpAddr>, preference: AddressFamilyPreference) -> Vec<IpAddr> {
+    let (mut preferred, mut other): (Vec<IpAddr>, Vec<IpAddr>) = match preference {
+        AddressFamilyPreference::Ipv6First => addrs.into_iter().partition(|ip| ip.is_ipv6()),
+        AddressFamilyPreference::Ipv4First => addrs.into_iter().partition(|ip| ip.is_ipv4()),
+    };
+
+    preferred.sort_by(rfc6724_compare);
+    other.sort_by(rfc6724_compare);
+
+    let mut result = Vec::with_capacity(preferred.len() + other.len());
+
+    let mut p = preferred.into_iter();
+    let mut o = other.into_iter();
+
+    loop {
+        match (p.next(), o.next()) {
+            (Some(a), Some(b)) => {
+                result.push(a);
+                result.push(b);
+            }
+            (Some(a), None) => result.push(a),
+            (None, Some(b)) => result.push(b),
+            (None, None) => break,
+        };
+    }
+
+    result
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Scope {
+    InterfaceLocal = 0x1,
+    LinkLocal = 0x2,
+    #[allow(dead_code)]
+    AdminLocal = 0x4,
+    SiteLocal = 0x5,
+    OrgLocal = 0x8,
+    Global = 0xe,
+}
+
+fn rfc6724_compare(a: &IpAddr, b: &IpAddr) -> std::cmp::Ordering {
+    // R1: TODO: Avoid unusable destinations. We need to compute reachability. Doable via netlink.
+    // R2: TODO: Prefer matching scope. We need to compute source addresses.
+
+    // R8: prefer smaller scope.
+
+    // A smaller-scope destination is "closer", thus preferred.
+    let sa = ip_scope(a);
+    let sb = ip_scope(b);
+    if sa != sb {
+        return sa.cmp(&sb);
+    }
+
+    // R3: not applicable.
+    // R4: not applicable.
+    // R5: not applicable (requires a policy table which we don't have).
+    // R6: this is the interleave step.
+    // R7: not important.
+    // R9: longest prefix matching.
+    // R10: OK.
+
+    Equal
+}
+
+fn ip_scope(addr: &IpAddr) -> Scope {
+    match addr {
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() {
+                Scope::InterfaceLocal
+            } else if v6.segments()[0] & 0xffc0 == 0xfe80 {
+                Scope::LinkLocal
+            } else if v6.segments()[0] & 0xffc0 == 0xfec0 {
+                Scope::SiteLocal
+            } else if v6.segments()[0] & 0xfe00 == 0xfc00 {
+                Scope::OrgLocal
+            } else {
+                Scope::Global
+            }
+        }
+        IpAddr::V4(v4) => {
+            if v4.is_loopback() {
+                Scope::InterfaceLocal
+            } else if v4.is_link_local() {
+                Scope::LinkLocal
+            } else if v4.is_private() {
+                Scope::SiteLocal
+            } else {
+                Scope::Global
+            }
+        }
+    }
+}
+
 fn build_hickory(servers: &[IpAddr], timeout: Duration) -> anyhow::Result<TokioResolver> {
     let name_servers: Vec<NameServerConfig> = servers
         .iter()
@@ -104,12 +378,194 @@ fn build_hickory(servers: &[IpAddr], timeout: Duration) -> anyhow::Result<TokioR
 
     let mut opts = ResolverOpts::default();
     opts.timeout = timeout;
-    // Default is Ipv6AndIpv4:
-    // https://docs.rs/hickory-resolver/0.26.1/src/hickory_resolver/config.rs.html#709
-    opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
 
     TokioResolver::builder_with_config(config, TokioRuntimeProvider::default())
         .with_options(opts)
         .build()
         .map_err(|err| anyhow::anyhow!("failed to build DNS resolver: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::net::TcpListener;
+
+    /// Start a TCP listener on localhost, return its SocketAddr.
+    async fn bind_ephemeral() -> SocketAddr {
+        TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap()
+            .local_addr()
+            .unwrap()
+    }
+
+    /// Spawn an acceptor that accepts one connection and immediately drops it.
+    fn spawn_accept_one(listener: TcpListener) {
+        tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+    }
+
+    #[tokio::test]
+    async fn single_ipv4_connect_success() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        spawn_accept_one(listener);
+
+        let result =
+            happy_eyeballs_connect_addrs(vec![addr.ip()], addr.port(), Duration::from_secs(2))
+                .await;
+
+        assert!(result.is_ok(), "expected connection to succeed");
+        let (_stream, connected_addr) = result.unwrap();
+        assert_eq!(connected_addr.port(), addr.port());
+    }
+
+    #[tokio::test]
+    async fn single_ipv4_connect_failure() {
+        // Use a port where nothing is listening.
+        // Bind to get a port, then drop the listener so it's closed.
+        let addr = bind_ephemeral().await;
+        // addr is now free (listener dropped)
+
+        let result =
+            happy_eyeballs_connect_addrs(vec![addr.ip()], addr.port(), Duration::from_millis(200))
+                .await;
+
+        assert!(result.is_err(), "expected connection to fail");
+    }
+
+    #[tokio::test]
+    async fn empty_address_list() {
+        let result = happy_eyeballs_connect_addrs(vec![], 80, Duration::from_secs(2)).await;
+
+        assert!(result.is_err(), "expected empty address list to error");
+    }
+
+    #[tokio::test]
+    async fn happy_eyeballs_falls_back_to_ipv4_when_ipv6_unreachable() {
+        // Set up a real IPv4 listener.
+        let v4_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let v4_addr = v4_listener.local_addr().unwrap();
+        spawn_accept_one(v4_listener);
+
+        // Use an unreachable IPv6 address (::1 on a random high port with
+        // nothing listening).  We put it *first* so a naive sequential
+        // implementation would time out on it before trying IPv4.
+        let unreachable_v6 = std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST);
+
+        let addrs = vec![unreachable_v6, v4_addr.ip()];
+        let start = tokio::time::Instant::now();
+
+        let result =
+            happy_eyeballs_connect_addrs(addrs, v4_addr.port(), Duration::from_millis(500)).await;
+
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_ok(),
+            "expected Happy Eyeballs to fall back to IPv4"
+        );
+        let (_stream, connected_addr) = result.unwrap();
+        assert_eq!(connected_addr.ip(), v4_addr.ip());
+        assert_eq!(connected_addr.port(), v4_addr.port());
+
+        // The connect should succeed roughly after RESOLUTION_DELAY + connect time,
+        // certainly faster than waiting for the full IPv6 timeout sequentially.
+        // With sequential: 500ms (IPv6 timeout) + connect time > 500ms.
+        // With Happy Eyeballs: ~250ms (delay) + connect time < 500ms.
+        // We use a bound with extra space to avoid flakiness.
+        assert!(
+            elapsed < Duration::from_millis(800),
+            "Happy Eyeballs should connect faster than sequential: took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn happy_eyeballs_ipv6_succeeds_immediately() {
+        // When IPv6 is reachable, it should win immediately (no resolution delay
+        // penalty).
+        let v6_listener = TcpListener::bind("[::1]:0").await.unwrap();
+        let v6_addr = v6_listener.local_addr().unwrap();
+        spawn_accept_one(v6_listener);
+
+        let start = tokio::time::Instant::now();
+
+        let result = happy_eyeballs_connect_addrs(
+            vec![v6_addr.ip()],
+            v6_addr.port(),
+            Duration::from_secs(2),
+        )
+        .await;
+
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok(), "expected IPv6 connection to succeed");
+        // Should connect almost immediately, well under 100ms locally.
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "IPv6 connect should be fast, took {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_ipv4_first_unreachable_second_reachable() {
+        // Within a single family, the algorithm should try the second address
+        // after the first fails.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let good_addr = listener.local_addr().unwrap();
+        spawn_accept_one(listener);
+
+        // Get a dead port — bind then immediately drop.
+        let dead_addr = bind_ephemeral().await;
+
+        let addrs = vec![dead_addr.ip(), good_addr.ip()];
+
+        let result =
+            happy_eyeballs_connect_addrs(addrs, good_addr.port(), Duration::from_millis(300)).await;
+
+        assert!(
+            result.is_ok(),
+            "expected fallback to second address within same family"
+        );
+        let (_stream, connected_addr) = result.unwrap();
+        assert_eq!(connected_addr.ip(), good_addr.ip());
+    }
+
+    #[tokio::test]
+    async fn cancellation_cancels_pending_connections() {
+        // This test verifies that when one connection succeeds, it immediately finishes.
+
+        // Create a slow listener that accepts after a delay
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        // Spawn a slow acceptor (accepts after 1000ms)
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(2000)).await;
+            let _ = listener.accept().await;
+        });
+
+        // Create a second listener that accepts immediately
+        let listener2 = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr2 = listener2.local_addr().unwrap();
+        spawn_accept_one(listener2);
+
+        let addrs = vec![addr.ip(), addr2.ip()];
+
+        let start = tokio::time::Instant::now();
+        let result =
+            happy_eyeballs_connect_addrs(addrs, addr2.port(), Duration::from_secs(5)).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok(), "connection should succeed");
+
+        // The second connection (addr2) should succeed quickly.
+        // The first connection attempt should be cancelled when the second succeeds.
+        // Since addr2 is reachable immediately, the total time should be short.
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "Should connect quickly without waiting for slow connection: took {elapsed:?}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crate::systemd::sd_notify_ready;
 
 mod acl;
 mod config;
+mod dns;
 mod logging;
 mod proxy;
 mod rpc;
@@ -288,6 +289,9 @@ async fn main() -> Result<()> {
                 state::init(&settings).context("While initializing application state")?,
             ));
 
+            let proxy_rt = proxy::ProxyRuntime::new(settings.clone(), state.clone())
+                .context("While building proxy runtime")?;
+
             debug!("Loaded Portail settings and state");
 
             let fds_named = systemd::listen_fds_named();
@@ -319,7 +323,7 @@ async fn main() -> Result<()> {
             info!("Starting services");
 
             let (proxy_fut, rpc_fut) = (
-                proxy::start(settings.clone(), state.clone(), tcp_listener),
+                proxy::start(proxy_rt, tcp_listener),
                 rpc::start(settings.clone(), state.clone(), rpc_listener),
             );
 

--- a/src/proxy/context.rs
+++ b/src/proxy/context.rs
@@ -52,7 +52,6 @@ impl From<fast_socks5::util::target_addr::TargetAddr> for TargetAddr {
 #[derive(Debug)]
 pub struct TargetContext {
     pub initial_target: TargetAddr,
-    pub resolved_target: Option<TargetAddr>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -1,12 +1,11 @@
 use crate::acl::ACLRules;
+use crate::config::BackendSettings;
 use crate::config::KnownBackend;
+use crate::proxy::connect_tcp;
 use crate::proxy::context::{LocalRequestContext, OwnedRequestContext};
 use crate::proxy::protocol_detect::{ALPN_H2, ALPN_HTTP1_1};
-use crate::{
-    config::{BackendSettings, Settings},
-    proxy::{ProxyError, client_tls},
-    state::State,
-};
+use crate::proxy::{ProxyError, ProxyRuntime, client_tls};
+use crate::state::State;
 use bytes::Bytes;
 use http::uri::Authority;
 use http_body_util::{BodyExt, Empty, combinators::BoxBody};
@@ -98,8 +97,7 @@ fn assess_request(
 /// - https://github.com/hyperium/hyper/blob/master/examples/upgrades.rs
 #[tracing::instrument(skip_all, fields(trace_id = %ctx.trace_id, client_address = %ctx.client_address, subsystem = "proxy_access"))]
 pub async fn serve_http1_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
-    settings: Arc<Settings>,
-    state: Arc<RwLock<State>>,
+    rt: Arc<ProxyRuntime>,
     ctx: OwnedRequestContext,
     stream: S,
 ) -> Result<(), ProxyError> {
@@ -112,13 +110,7 @@ pub async fn serve_http1_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
         .serve_connection(
             io,
             service_fn(move |req| {
-                handle_http_request(
-                    req,
-                    ctx.clone(),
-                    settings.clone(),
-                    state.clone(),
-                    InboundHttpProtocol::Http1,
-                )
+                handle_http_request(req, ctx.clone(), rt.clone(), InboundHttpProtocol::Http1)
             }),
         )
         .with_upgrades()
@@ -130,8 +122,7 @@ pub async fn serve_http1_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
 
 #[tracing::instrument(skip_all, fields(trace_id = %ctx.trace_id, client_address = %ctx.client_address, subsystem = "proxy_access"))]
 pub async fn serve_http2_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'static>(
-    settings: Arc<Settings>,
-    state: Arc<RwLock<State>>,
+    rt: Arc<ProxyRuntime>,
     ctx: OwnedRequestContext,
     stream: S,
 ) -> Result<(), ProxyError> {
@@ -148,13 +139,7 @@ pub async fn serve_http2_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
         .serve_connection(
             io,
             service_fn(move |req| {
-                handle_http_request(
-                    req,
-                    ctx.clone(),
-                    settings.clone(),
-                    state.clone(),
-                    InboundHttpProtocol::Http2,
-                )
+                handle_http_request(req, ctx.clone(), rt.clone(), InboundHttpProtocol::Http2)
             }),
         )
         .await
@@ -167,8 +152,7 @@ pub async fn serve_http2_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
 async fn handle_http_request(
     req: Request<Incoming>,
     initial_ctx: OwnedRequestContext,
-    settings: Arc<Settings>,
-    state: Arc<RwLock<State>>,
+    rt: Arc<ProxyRuntime>,
     inbound_protocol: InboundHttpProtocol,
 ) -> Result<Response<BoxBody<Bytes, hyper::Error>>, hyper::Error> {
     let mut ctx = initial_ctx.as_local();
@@ -222,11 +206,11 @@ async fn handle_http_request(
     let port = target_authority.port_u16().unwrap_or(CONNECT_DEFAULT_PORT);
     let mut final_address = format!("{}:{}", target_authority.host(), port);
     let mut backends: Vec<BackendSettings> = Vec::with_capacity(1);
-    let backend_specs = &state.read().await.backends;
+    let backend_specs = &rt.state.read().await.backends;
     debug!(subsystem = "proxy_access", final_address = %final_address,
         "HTTP CONNECT request");
     // We evaluate first whether we are allowed then we evaluate routes.
-    let acl = &state.read().await.acl_rules;
+    let acl = &rt.state.read().await.acl_rules;
 
     ctx.acl_ctx.insert(
         "host",
@@ -274,9 +258,10 @@ async fn handle_http_request(
     }
 
     if backends.is_empty()
-        && let Some(ref backend_id) = state.read().await.default_backend
+        && let Some(ref backend_id) = rt.state.read().await.default_backend
     {
-        let backend = state
+        let backend = rt
+            .state
             .read()
             .await
             .backends
@@ -334,11 +319,11 @@ async fn handle_http_request(
             }
             BackendSettings::KnownBackend(backend) => {
                 match timeout(
-                    settings.request_timeout,
+                    rt.settings.request_timeout,
                     connect_to_http_proxy_backend(
                         &backend,
                         &final_address,
-                        state.clone(),
+                        rt.state.clone(),
                         &inbound_protocol,
                     ),
                 )
@@ -392,7 +377,7 @@ async fn handle_http_request(
                             subsystem = "proxy_access",
                             backend = ?backend,
                             duration_ms = start.elapsed().as_millis(),
-                            configured_timeout_ms = settings.request_timeout.as_millis(),
+                            configured_timeout_ms = rt.settings.request_timeout.as_millis(),
                             "Backend timed out for HTTP CONNECT, trying next",
                         );
                     }
@@ -428,28 +413,65 @@ async fn handle_http_request(
         );
 
         let start = Instant::now();
-        match timeout(settings.request_timeout, TcpStream::connect(&final_address)).await {
-            Ok(Ok(socket)) => {
+        let authority: Authority = match final_address.parse() {
+            Ok(authority) => authority,
+            Err(_) => {
+                warn!(
+                    subsystem = "proxy_errors",
+                    address = %final_address,
+                    duration_ms = start.elapsed().as_millis(),
+                    "Direct connection target is an invalid authority",
+                );
+                let mut resp = Response::new(empty_body());
+                *resp.status_mut() = StatusCode::BAD_REQUEST;
+                return Ok(resp);
+            }
+        };
+
+        let port = authority.port_u16().unwrap_or(default_port);
+        let ips = match rt.dns.lookup(authority.host()).await {
+            Ok(ips) => {
+                debug!(
+                    subsystem = "proxy_access",
+                    host = %authority.host(),
+                    port = %port,
+                    address_count = ips.len(),
+                    duration_ms = start.elapsed().as_millis(),
+                    "HTTP CONNECT DNS resolution successful",
+                );
+                ips
+            }
+            Err(err) => {
+                warn!(
+                    subsystem = "proxy_errors",
+                    address = %final_address,
+                    duration_ms = start.elapsed().as_millis(),
+                    "Direct connection DNS resolution failed: {err}",
+                );
+                let mut resp = Response::new(empty_body());
+                *resp.status_mut() = StatusCode::BAD_GATEWAY;
+                return Ok(resp);
+            }
+        };
+
+        match connect_tcp(&ips, port, rt.settings.request_timeout).await {
+            Ok((socket, resolved_target)) => {
                 info!(
                     subsystem = "proxy_access",
                     address = %final_address,
+                    resolved_target = %resolved_target,
                     duration_ms = start.elapsed().as_millis(),
                     "Stream directly established to final address (local exit)"
                 );
                 stream = Some(Box::new(socket))
             }
-            Ok(Err(e)) => warn!(
+            Err(e) => warn!(
                 subsystem = "proxy_errors",
                 address = %final_address,
                 duration_ms = start.elapsed().as_millis(),
+                configured_timeout_ms = rt.settings.request_timeout.as_millis(),
                 "Direct connection failed: {}",
-                e),
-            Err(_) => warn!(
-                subsystem = "proxy_errors",
-                address = %final_address,
-                duration_ms = start.elapsed().as_millis(),
-                configured_timeout_ms = settings.request_timeout.as_millis(),
-                "Direct connection failed due to timeout",
+                e
             ),
         }
     }

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -1,7 +1,7 @@
 use crate::acl::ACLRules;
 use crate::config::BackendSettings;
 use crate::config::KnownBackend;
-use crate::proxy::connect_tcp;
+use crate::dns::happy_eyeballs_connect;
 use crate::proxy::context::{LocalRequestContext, OwnedRequestContext};
 use crate::proxy::protocol_detect::{ALPN_H2, ALPN_HTTP1_1};
 use crate::proxy::{ProxyError, ProxyRuntime, client_tls};
@@ -428,50 +428,31 @@ async fn handle_http_request(
             }
         };
 
-        let port = authority.port_u16().unwrap_or(default_port);
-        let ips = match rt.dns.lookup(authority.host()).await {
-            Ok(ips) => {
-                debug!(
-                    subsystem = "proxy_access",
-                    host = %authority.host(),
-                    port = %port,
-                    address_count = ips.len(),
-                    duration_ms = start.elapsed().as_millis(),
-                    "HTTP CONNECT DNS resolution successful",
-                );
-                ips
-            }
-            Err(err) => {
-                warn!(
-                    subsystem = "proxy_errors",
-                    address = %final_address,
-                    duration_ms = start.elapsed().as_millis(),
-                    "Direct connection DNS resolution failed: {err}",
-                );
-                let mut resp = Response::new(empty_body());
-                *resp.status_mut() = StatusCode::BAD_GATEWAY;
-                return Ok(resp);
-            }
-        };
-
-        match connect_tcp(&ips, port, rt.settings.request_timeout).await {
+        match happy_eyeballs_connect(
+            &rt.dns,
+            authority.host(),
+            port,
+            rt.settings.request_timeout,
+            rt.settings.tcp_nodelay,
+        )
+        .await
+        {
             Ok((socket, resolved_target)) => {
                 info!(
                     subsystem = "proxy_access",
                     address = %final_address,
                     resolved_target = %resolved_target,
                     duration_ms = start.elapsed().as_millis(),
-                    "Stream directly established to final address (local exit)"
+                    "Stream directly established to final address via Happy Eyeballs (local exit)"
                 );
                 stream = Some(Box::new(socket))
             }
-            Err(e) => warn!(
+            Err(err) => warn!(
                 subsystem = "proxy_errors",
                 address = %final_address,
                 duration_ms = start.elapsed().as_millis(),
                 configured_timeout_ms = rt.settings.request_timeout.as_millis(),
-                "Direct connection failed: {}",
-                e
+                "Direct connection via Happy Eyeballs failed: {err}",
             ),
         }
     }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,8 +1,11 @@
 use anyhow::bail;
 use fast_socks5::SocksError;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::time::Duration;
 use thiserror::Error;
-use tokio::{net::TcpStream, sync::RwLock};
+use tokio::{net::TcpStream, sync::RwLock, time::timeout};
 use tokio_rustls::{
     TlsAcceptor, TlsStream,
     rustls::{
@@ -12,7 +15,9 @@ use tokio_rustls::{
 };
 use tracing::{Instrument, debug, error};
 
-use crate::{config::Settings, proxy::context::OwnedRequestContext, state::State};
+use crate::{
+    config::Settings, dns::DnsResolver, proxy::context::OwnedRequestContext, state::State,
+};
 
 mod client_tls;
 mod context;
@@ -25,6 +30,24 @@ use http_connect::{serve_http1_connect, serve_http2_connect};
 use protocol_detect::{ALPN_H2, ALPN_HTTP1_1, DetectedProtocol, detect_protocol, detect_tls};
 use socks5::serve_socks5;
 
+pub struct ProxyRuntime {
+    pub settings: Arc<Settings>,
+    pub state: Arc<RwLock<State>>,
+    pub dns: Arc<DnsResolver>,
+}
+
+impl ProxyRuntime {
+    pub fn new(settings: Arc<Settings>, state: Arc<RwLock<State>>) -> anyhow::Result<Arc<Self>> {
+        let dns = DnsResolver::from_settings(&settings.dns)?;
+
+        Ok(Arc::new(Self {
+            settings,
+            state,
+            dns,
+        }))
+    }
+}
+
 #[derive(Debug, Error)]
 enum ProxyError {
     #[error("SOCKS5 error: {0}")]
@@ -34,8 +57,7 @@ enum ProxyError {
 }
 
 async fn serve_authenticated_proxy(
-    settings: Arc<Settings>,
-    state: Arc<RwLock<State>>,
+    rt: Arc<ProxyRuntime>,
     ctx: OwnedRequestContext,
     stream: TlsStream<tokio::net::TcpStream>,
 ) -> anyhow::Result<()> {
@@ -45,9 +67,9 @@ async fn serve_authenticated_proxy(
 
     if let InboundStream::TlsStream(stream) = stream {
         match proto {
-            DetectedProtocol::Socks5 => serve_socks5(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http1 => serve_http1_connect(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http2 => serve_http2_connect(settings, state, ctx, stream).await?,
+            DetectedProtocol::Socks5 => serve_socks5(rt, ctx, stream).await?,
+            DetectedProtocol::Http1 => serve_http1_connect(rt, ctx, stream).await?,
+            DetectedProtocol::Http2 => serve_http2_connect(rt, ctx, stream).await?,
             DetectedProtocol::Unknown => bail!("Unknown protocol"),
         }
     }
@@ -56,17 +78,16 @@ async fn serve_authenticated_proxy(
 }
 
 async fn serve_unauthenticated_proxy(
-    settings: Arc<Settings>,
-    state: Arc<RwLock<State>>,
+    rt: Arc<ProxyRuntime>,
     ctx: OwnedRequestContext,
     stream: tokio::net::TcpStream,
 ) -> anyhow::Result<()> {
     let (proto, stream) = detect_protocol(InboundStream::TcpStream(stream)).await?;
     if let InboundStream::TcpStream(stream) = stream {
         match proto {
-            DetectedProtocol::Socks5 => serve_socks5(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http1 => serve_http1_connect(settings, state, ctx, stream).await?,
-            DetectedProtocol::Http2 => serve_http2_connect(settings, state, ctx, stream).await?,
+            DetectedProtocol::Socks5 => serve_socks5(rt, ctx, stream).await?,
+            DetectedProtocol::Http1 => serve_http1_connect(rt, ctx, stream).await?,
+            DetectedProtocol::Http2 => serve_http2_connect(rt, ctx, stream).await?,
             DetectedProtocol::Unknown => bail!("Unknown protocol"),
         }
     }
@@ -116,8 +137,7 @@ async fn build_tls_acceptor(
 
 #[tracing::instrument(skip_all, fields(trace_id = %ctx.trace_id, client_address = %ctx.client_address, subsystem = "proxy_access"))]
 pub async fn accept_client(
-    settings: Arc<Settings>,
-    state: Arc<RwLock<State>>,
+    rt: Arc<ProxyRuntime>,
     socket: TcpStream,
     tls_acceptor: Option<TlsAcceptor>,
     ctx: OwnedRequestContext,
@@ -125,8 +145,7 @@ pub async fn accept_client(
     debug!(subsystem = "proxy_access", "Accepting a proxy connection");
 
     let acceptor = tls_acceptor.clone();
-    let settings = settings.clone();
-    let state = state.clone();
+    let rt = rt.clone();
 
     tokio::spawn(
         async move {
@@ -141,8 +160,7 @@ pub async fn accept_client(
                                     "Authenticated TLS stream (client certificates)"
                                 );
                                 if let Err(e) = serve_authenticated_proxy(
-                                    settings,
-                                    state,
+                                    rt,
                                     ctx,
                                     TlsStream::Server(tls_stream),
                                 )
@@ -168,8 +186,7 @@ pub async fn accept_client(
                         subsystem = "proxy_access",
                         "No TLS detected, serving unauthenticated requests",
                     );
-                    if let Err(e) = serve_unauthenticated_proxy(settings, state, ctx, socket).await
-                    {
+                    if let Err(e) = serve_unauthenticated_proxy(rt, ctx, socket).await {
                         error!(subsystem = "proxy_errors", "Proxy error: {e:?}");
                     }
                 }
@@ -186,23 +203,40 @@ pub async fn accept_client(
     );
 }
 
-pub async fn start(
-    settings: Arc<Settings>,
-    state: Arc<RwLock<State>>,
-    listener: tokio::net::TcpListener,
-) -> anyhow::Result<()> {
-    let tls_acceptor: Option<TlsAcceptor> = build_tls_acceptor(&settings, state.clone()).await?;
+pub async fn start(rt: Arc<ProxyRuntime>, listener: tokio::net::TcpListener) -> anyhow::Result<()> {
+    let tls_acceptor: Option<TlsAcceptor> =
+        build_tls_acceptor(&rt.settings, rt.state.clone()).await?;
 
     loop {
         let (socket, addr) = listener.accept().await?;
         let ctx = OwnedRequestContext::new(addr);
-        accept_client(
-            settings.clone(),
-            state.clone(),
-            socket,
-            tls_acceptor.clone(),
-            ctx,
-        )
-        .await;
+        accept_client(rt.clone(), socket, tls_acceptor.clone(), ctx).await;
     }
+}
+
+/// Tries each address in order.
+pub(crate) async fn connect_tcp(
+    ips: &[IpAddr],
+    port: u16,
+    connect_timeout: Duration,
+) -> io::Result<(TcpStream, SocketAddr)> {
+    let per_addr_timeout = connect_timeout
+        .checked_div(ips.len().max(1) as u32)
+        .unwrap_or(connect_timeout);
+    let mut last_err = None;
+
+    for &ip in ips {
+        let addr = SocketAddr::new(ip, port);
+        match timeout(per_addr_timeout, TcpStream::connect(addr)).await {
+            Ok(Ok(stream)) => return Ok((stream, addr)),
+            Ok(Err(err)) => last_err = Some(err),
+            Err(err) => {
+                last_err = Some(io::Error::new(io::ErrorKind::TimedOut, err));
+            }
+        }
+    }
+
+    Err(last_err.unwrap_or_else(|| {
+        io::Error::new(io::ErrorKind::NotConnected, "no addresses to connect to")
+    }))
 }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,11 +1,8 @@
 use anyhow::bail;
 use fast_socks5::SocksError;
-use std::io;
-use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
-use std::time::Duration;
 use thiserror::Error;
-use tokio::{net::TcpStream, sync::RwLock, time::timeout};
+use tokio::{net::TcpStream, sync::RwLock};
 use tokio_rustls::{
     TlsAcceptor, TlsStream,
     rustls::{
@@ -212,31 +209,4 @@ pub async fn start(rt: Arc<ProxyRuntime>, listener: tokio::net::TcpListener) -> 
         let ctx = OwnedRequestContext::new(addr);
         accept_client(rt.clone(), socket, tls_acceptor.clone(), ctx).await;
     }
-}
-
-/// Tries each address in order.
-pub(crate) async fn connect_tcp(
-    ips: &[IpAddr],
-    port: u16,
-    connect_timeout: Duration,
-) -> io::Result<(TcpStream, SocketAddr)> {
-    let per_addr_timeout = connect_timeout
-        .checked_div(ips.len().max(1) as u32)
-        .unwrap_or(connect_timeout);
-    let mut last_err = None;
-
-    for &ip in ips {
-        let addr = SocketAddr::new(ip, port);
-        match timeout(per_addr_timeout, TcpStream::connect(addr)).await {
-            Ok(Ok(stream)) => return Ok((stream, addr)),
-            Ok(Err(err)) => last_err = Some(err),
-            Err(err) => {
-                last_err = Some(io::Error::new(io::ErrorKind::TimedOut, err));
-            }
-        }
-    }
-
-    Err(last_err.unwrap_or_else(|| {
-        io::Error::new(io::ErrorKind::NotConnected, "no addresses to connect to")
-    }))
 }

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -20,7 +20,7 @@ use tracing::{debug, info, warn};
 use crate::{
     acl::ACLRules,
     config::{BackendSettings, KnownBackend},
-    dns::{DnsError, DnsResolver},
+    dns::{DnsError, HappyEyeballsError, happy_eyeballs_connect},
     proxy::{
         ProxyRuntime,
         context::{LocalRequestContext, OwnedRequestContext, TargetContext},
@@ -382,32 +382,62 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         let start = Instant::now();
         match (cmd, rt.settings.public_address) {
             (Socks5Command::TCPConnect, _) => {
-                let resolved_target = resolve(&rt.dns, final_addr, start).await?;
-                debug!(
-                    subsystem = "proxy_access",
-                    target_addr = %resolved_target,
-                    duration_ms = start.elapsed().as_millis(),
-                    "SOCKS5 direct exit target address resolved"
-                );
-
-                // TODO: run_tcp_proxy only tries one address.
-                fast_socks5::server::run_tcp_proxy(
-                    proto,
-                    &TargetAddr::Ip(resolved_target),
+                let (host, port) = final_addr.into_string_and_port();
+                let (stream, resolved_addr) = happy_eyeballs_connect(
+                    &rt.dns,
+                    &host,
+                    port,
                     rt.settings.request_timeout,
                     rt.settings.tcp_nodelay,
                 )
-                .await?;
+                .await
+                .map_err(|err| {
+                    warn!(
+                        subsystem = "proxy_errors",
+                        host = %host,
+                        port = %port,
+                        duration_ms = start.elapsed().as_millis(),
+                        "SOCKS5 Happy Eyeballs connection failed: {err}",
+                    );
+                    match err {
+                        HappyEyeballsError::Dns(dns_err) => match dns_err {
+                            DnsError::LookupFailed { source, .. } => {
+                                SocksError::AddrError(AddrError::DNSResolutionFailed(source))
+                            }
+                            DnsError::TimedOut { .. } => SocksError::AddrError(
+                                AddrError::DNSResolutionFailed(std::io::Error::other(dns_err)),
+                            ),
+                            DnsError::NoRecords { .. } => {
+                                SocksError::AddrError(AddrError::NoDNSRecords)
+                            }
+                        },
+                        HappyEyeballsError::AllFailed { .. }
+                        | HappyEyeballsError::NoAddresses { .. } => {
+                            SocksError::ReplyError(ReplyError::HostUnreachable)
+                        }
+                    }
+                })?;
+
+                debug!(
+                    subsystem = "proxy_access",
+                    target_addr = %resolved_addr,
+                    duration_ms = start.elapsed().as_millis(),
+                    "SOCKS5 Happy Eyeballs connection established"
+                );
+
+                let inner = proto
+                    .reply_success(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0))
+                    .await?;
+                fast_socks5::server::transfer(inner, stream).await;
             }
 
             // TODO: enable with ACL rules evaluation
             // (Socks5Command::UDPAssociate, Some(public_address)) => {
-                // TODO: fast_socks5 does its own DNS resolution on each UDP packet using the system resolver.
-                // https://github.com/dizda/fast-socks5/blob/acb847616ec44b6c2d6cdaddeba090d18c6c5d5c/src/server.rs#L1245
+            // TODO: fast_socks5 does its own DNS resolution on each UDP packet using the system resolver.
+            // https://github.com/dizda/fast-socks5/blob/acb847616ec44b6c2d6cdaddeba090d18c6c5d5c/src/server.rs#L1245
             //    fast_socks5::server::run_udp_proxy(proto, &final_addr, None, public_address, None)
             //        .await?;
             //}
-
             _ => {
                 proto.reply_error(&ReplyError::CommandNotSupported).await?;
                 return Err(ReplyError::CommandNotSupported.into());
@@ -421,52 +451,4 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     }
 
     Ok(())
-}
-
-async fn resolve(
-    dns: &DnsResolver,
-    target: TargetAddr,
-    start: Instant,
-) -> Result<SocketAddr, SocksError> {
-    match target {
-        TargetAddr::Ip(addr) => Ok(addr),
-        TargetAddr::Domain(host, port) => match dns.lookup(&host).await {
-            Ok(ips) => {
-                let ip = ips
-                    .into_iter()
-                    .next()
-                    .expect("Broken invariant: lookup returns at least one address");
-                let resolved_target = SocketAddr::new(ip, port);
-                debug!(
-                    subsystem = "proxy_access",
-                    host = %host,
-                    port = %port,
-                    resolved_target = %resolved_target,
-                    duration_ms = start.elapsed().as_millis(),
-                    "SOCKS5 DNS resolution successful",
-                );
-                Ok(resolved_target)
-            }
-            Err(err) => {
-                warn!(
-                    subsystem = "proxy_errors",
-                    host = %host,
-                    port = %port,
-                    duration_ms = start.elapsed().as_millis(),
-                    "SOCKS5 DNS resolution failed: {err}",
-                );
-                match err {
-                    DnsError::LookupFailed { source, .. } => Err(SocksError::AddrError(
-                        AddrError::DNSResolutionFailed(source),
-                    )),
-                    DnsError::TimedOut { .. } => Err(SocksError::AddrError(
-                        AddrError::DNSResolutionFailed(std::io::Error::other(err)),
-                    )),
-                    DnsError::NoRecords { .. } => {
-                        Err(SocksError::AddrError(AddrError::NoDNSRecords))
-                    }
-                }
-            }
-        },
-    }
 }

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -4,13 +4,14 @@ use std::{
 };
 
 use fast_socks5::{
-    ReplyError, Socks5Command, SocksError, client::Socks5Stream, server::Socks5ServerProtocol,
-    util::target_addr::TargetAddr,
+    ReplyError, Socks5Command, SocksError,
+    client::Socks5Stream,
+    server::Socks5ServerProtocol,
+    util::target_addr::{AddrError, TargetAddr},
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,
-    sync::RwLock,
     time::{Instant, timeout},
 };
 use tokio_rustls::TlsStream;
@@ -18,9 +19,12 @@ use tracing::{debug, info, warn};
 
 use crate::{
     acl::ACLRules,
-    config::{BackendSettings, KnownBackend, Settings},
-    proxy::context::{LocalRequestContext, OwnedRequestContext, TargetContext},
-    state::State,
+    config::{BackendSettings, KnownBackend},
+    dns::{DnsError, DnsResolver},
+    proxy::{
+        ProxyRuntime,
+        context::{LocalRequestContext, OwnedRequestContext, TargetContext},
+    },
 };
 
 #[allow(clippy::large_enum_variant)]
@@ -90,10 +94,11 @@ fn assess_request(
     }
 }
 
+// TODO: better error type
 pub async fn connect_to_backend(
     backend: &KnownBackend,
     final_address: &TargetAddr,
-    state: Arc<RwLock<State>>, // TODO: better error type
+    rt: Arc<ProxyRuntime>,
 ) -> Result<OutboundSock5Stream, SocksError> {
     let config = fast_socks5::client::Config::default();
     let (target_addr, target_port) = final_address.clone().into_string_and_port();
@@ -105,7 +110,7 @@ pub async fn connect_to_backend(
         let stream = crate::proxy::client_tls::connect_using_tls_auth(
             target_socket,
             domain,
-            state.clone(),
+            rt.state.clone(),
             vec![],
         )
         .await?;
@@ -142,12 +147,10 @@ pub async fn route_to_backend<S: AsyncRead + Unpin + AsyncWrite>(
 
 #[tracing::instrument(skip_all, fields(trace_id = %ctx.trace_id, client_address = %ctx.client_address, subsystem = "proxy_access"))]
 pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
-    opts: Arc<Settings>,
-    state: Arc<RwLock<State>>,
+    rt: Arc<ProxyRuntime>,
     ctx: OwnedRequestContext,
     socket: S,
 ) -> Result<(), SocksError> {
-    let should_resolve_dns: bool = state.read().await.default_backend.is_none();
     let start = Instant::now();
 
     let (proto, cmd, target_addr) = Socks5ServerProtocol::accept_no_auth(socket)
@@ -163,25 +166,9 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     );
     let start = Instant::now();
 
-    let mut target_context = TargetContext {
+    let target_context = TargetContext {
         initial_target: target_addr.clone().into(),
-        resolved_target: None,
     };
-
-    let target_addr = if should_resolve_dns {
-        target_addr.resolve_dns().await?
-    } else {
-        target_addr
-    };
-
-    debug!(
-        subsystem = "proxy_access",
-        target_addr = %target_addr,
-        duration_ms = %start.elapsed().as_millis(),
-        "SOCKS5 resolved target address obtained"
-    );
-
-    let start = Instant::now();
 
     let (host, port) = target_context.initial_target.clone().into_string_and_port();
 
@@ -197,13 +184,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         crate::acl::ast::ConcreteOperand::Number(port.into()),
     );
 
-    let mut final_addr = target_addr.clone();
-
-    target_context.resolved_target = if should_resolve_dns {
-        Some(target_addr.into())
-    } else {
-        None
-    };
+    let mut final_addr = target_addr;
 
     // TODO: enable UDP ASSOCIATE once ACL rules are evaluated on each UDP packet
     if cmd != Socks5Command::TCPConnect {
@@ -237,8 +218,8 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     );
 
     let mut backends: Vec<BackendSettings> = Vec::with_capacity(1);
-    let acl = &state.read().await.acl_rules;
-    let backend_specs = &state.read().await.backends;
+    let acl = &rt.state.read().await.acl_rules;
+    let backend_specs = &rt.state.read().await.backends;
 
     // We evaluate first the routes as it can influence the ACL in case of a local exit.
     let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(backend_specs, &acl.hir) {
@@ -258,9 +239,10 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     }
 
     if backends.is_empty()
-        && let Some(ref backend_id) = state.read().await.default_backend
+        && let Some(ref backend_id) = rt.state.read().await.default_backend
     {
-        let backend = state
+        let backend = rt
+            .state
             .read()
             .await
             .backends
@@ -320,8 +302,8 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
             }
             BackendSettings::KnownBackend(backend) => {
                 match timeout(
-                    opts.request_timeout,
-                    connect_to_backend(&backend, &final_addr, state.clone()),
+                    rt.settings.request_timeout,
+                    connect_to_backend(&backend, &final_addr, rt.clone()),
                 )
                 .await
                 {
@@ -359,7 +341,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                     Err(_) => {
                         debug!(
                             "Backend {} timed out after {:?}, trying the next one",
-                            &backend.target_address, opts.request_timeout
+                            &backend.target_address, rt.settings.request_timeout
                         );
                         continue;
                     }
@@ -368,7 +350,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         }
     }
 
-    // If we get there, this means that we did not have any backend at all.
+    // Direct exit: if we get there, this means that we did not have any backend at all.
     {
         debug!(
             subsystem = "proxy_access",
@@ -398,22 +380,34 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         );
 
         let start = Instant::now();
-        match (cmd, opts.public_address) {
+        match (cmd, rt.settings.public_address) {
             (Socks5Command::TCPConnect, _) => {
+                let resolved_target = resolve(&rt.dns, final_addr, start).await?;
+                debug!(
+                    subsystem = "proxy_access",
+                    target_addr = %resolved_target,
+                    duration_ms = start.elapsed().as_millis(),
+                    "SOCKS5 direct exit target address resolved"
+                );
+
+                // TODO: run_tcp_proxy only tries one address.
                 fast_socks5::server::run_tcp_proxy(
                     proto,
-                    &final_addr,
-                    opts.request_timeout,
-                    opts.tcp_nodelay,
+                    &TargetAddr::Ip(resolved_target),
+                    rt.settings.request_timeout,
+                    rt.settings.tcp_nodelay,
                 )
                 .await?;
             }
 
             // TODO: enable with ACL rules evaluation
             // (Socks5Command::UDPAssociate, Some(public_address)) => {
-            //     fast_socks5::server::run_udp_proxy(proto, &final_addr, None, public_address, None)
-            //         .await?;
-            // }
+                // TODO: fast_socks5 does its own DNS resolution on each UDP packet using the system resolver.
+                // https://github.com/dizda/fast-socks5/blob/acb847616ec44b6c2d6cdaddeba090d18c6c5d5c/src/server.rs#L1245
+            //    fast_socks5::server::run_udp_proxy(proto, &final_addr, None, public_address, None)
+            //        .await?;
+            //}
+
             _ => {
                 proto.reply_error(&ReplyError::CommandNotSupported).await?;
                 return Err(ReplyError::CommandNotSupported.into());
@@ -427,4 +421,52 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     }
 
     Ok(())
+}
+
+async fn resolve(
+    dns: &DnsResolver,
+    target: TargetAddr,
+    start: Instant,
+) -> Result<SocketAddr, SocksError> {
+    match target {
+        TargetAddr::Ip(addr) => Ok(addr),
+        TargetAddr::Domain(host, port) => match dns.lookup(&host).await {
+            Ok(ips) => {
+                let ip = ips
+                    .into_iter()
+                    .next()
+                    .expect("Broken invariant: lookup returns at least one address");
+                let resolved_target = SocketAddr::new(ip, port);
+                debug!(
+                    subsystem = "proxy_access",
+                    host = %host,
+                    port = %port,
+                    resolved_target = %resolved_target,
+                    duration_ms = start.elapsed().as_millis(),
+                    "SOCKS5 DNS resolution successful",
+                );
+                Ok(resolved_target)
+            }
+            Err(err) => {
+                warn!(
+                    subsystem = "proxy_errors",
+                    host = %host,
+                    port = %port,
+                    duration_ms = start.elapsed().as_millis(),
+                    "SOCKS5 DNS resolution failed: {err}",
+                );
+                match err {
+                    DnsError::LookupFailed { source, .. } => Err(SocksError::AddrError(
+                        AddrError::DNSResolutionFailed(source),
+                    )),
+                    DnsError::TimedOut { .. } => Err(SocksError::AddrError(
+                        AddrError::DNSResolutionFailed(std::io::Error::other(err)),
+                    )),
+                    DnsError::NoRecords { .. } => {
+                        Err(SocksError::AddrError(AddrError::NoDNSRecords))
+                    }
+                }
+            }
+        },
+    }
 }


### PR DESCRIPTION
Fixes #129

Notes about this implementation:
1. request_timeout exactly respected, in the sense that a request could theoretically timeout after 3 times request_timeout. I think timeouts should be reworked at some point.
2. Trying multiple IPs in the socks5 tcp proxy involves a bit more code and I suggest we create an issue for that
3. DNS resolution for socks5 UDP associate is done per UDP packet, this one too, we might want to create an issue for it