### PR TITLE
nix/module: ensure that sockets are always spawned by systemd

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -129,6 +129,9 @@ in
       description = "Portail access proxy";
       wantedBy = mkIf cfg.enableAtBoot [ "multi-user.target" ];
 
+      after = [ "portail-rpc.socket" "portail-proxy.socket" ];
+      requires = [ "portail-rpc.socket" "portail-proxy.socket" ];
+
       serviceConfig = {
         # Use "notify-reload" when https://github.com/cloud-gouv/portail/issues/9 is done.
         Type = "notify";


### PR DESCRIPTION
systemd .socket units do not automatically add a WantedBy= or RequiredBy= on the socket units.

Therefore, systemd may start/restart our service without pulling the .socket units and creating the required sockets. To avoid this problem, let's make Portail fail if the sockets are not being opened by systemd itself.