### PR TITLE
tests/multiple-backend: correct SOCKS5 connection testcode

### DIFF
--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -878,7 +878,7 @@ in
 
       # Test SOCKS5 curl -> portail -> portail alpha -> corp-server
       result = json.loads(node.succeed(
-        "curl --fail --socks5 http://127.0.0.1:8080 http://hello.corp.example.com"
+        "curl --fail --socks5 127.0.0.1:8080 http://hello.corp.example.com"
       ))
 
       assert (
@@ -892,7 +892,7 @@ in
 
       # Test SOCKS5 curl -> portail -> microsocks beta -> corp-server
       result = json.loads(node.succeed(
-        "curl --fail --socks5 http://127.0.0.1:8080 http://hello.corp.example.com"
+        "curl --fail --socks5 127.0.0.1:8080 http://hello.corp.example.com"
       ))
 
       assert (


### PR DESCRIPTION
The test code tried to do SOCKS5 with HTTP somehow and this resulted in very weird behavior at the curl level.

This is now fixed, I'm surprised tests have passed… but, well, curl is known to have hiccups.