### PR TITLE
proxy/accept: handle transient accept errors and add connection cap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ http = "^1"
 http-body-util = "^0.1"
 hyper = { version = "^1", features = ["full"] }
 hyper-util = { version = "^0.1", features = ["tokio", "server", "http1"] }
-nix = { version = "^0.31", features = ["socket", "uio", "net"] }
+nix = { version = "^0.31", features = ["socket", "uio", "net", "resource"] }
 regex = "^1"
 serde = { version = "^1", features = ["derive"] }
 serde_json = "^1"

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -159,6 +159,8 @@ in
         RuntimeDirectory = "portail";
         StateDirectory = "portail";
         LogsDirectory = "portail";
+
+        LimitNOFILE = 130672;
       };
     };
   };

--- a/src/config.rs
+++ b/src/config.rs
@@ -215,6 +215,43 @@ pub struct Settings {
     /// Settings for the local RPC (authorization).
     #[serde(default)]
     pub rpc: RPCSettings,
+
+    /// Maximum number of concurrent client connections to the proxy.
+    ///
+    /// When this limit is reached, new connections are rejected until slots free up.
+    /// This prevents unbounded file descriptor growth if RLIMIT_NOFILE is too high.
+    /// Defaults to the (RLIMIT_NOFILE soft limit - 32) / 2,
+    /// what we consider to be the effective max.
+    #[serde(default = "default_max_connections")]
+    pub max_connections: usize,
+}
+
+pub fn effective_max_connections(upper_bound: usize) -> usize {
+    use nix::sys::resource::{Resource, getrlimit};
+
+    // We approximate there's 32 FDs which are independent of any connections
+    // (logs, RPC socket, etc.)
+    const RESERVED_FDS: u64 = 32;
+
+    let (soft, _hard) = match getrlimit(Resource::RLIMIT_NOFILE) {
+        Ok(l) => l,
+        // Assume there's danger and the limit is very low.
+        Err(_) => {
+            tracing::warn!(
+                "Could not figure out the soft RLIMIT_NOFILE, Portail will cap the number of client connections to 16."
+            );
+            return upper_bound.min(16);
+        }
+    };
+
+    let available = soft.saturating_sub(RESERVED_FDS);
+    let fd_based = (available / 2) as usize;
+
+    fd_based.min(upper_bound)
+}
+
+pub fn default_max_connections() -> usize {
+    effective_max_connections(usize::MAX)
 }
 
 pub fn init(config_path: &Path) -> Settings {

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,10 +320,19 @@ async fn main() -> Result<()> {
                 tokio::net::UnixListener::from_std(std)?
             };
 
+            let effective_max_conn = config::effective_max_connections(settings.max_connections);
+            if effective_max_conn < settings.max_connections {
+                tracing::warn!(
+                    "Configuration sets max connections at {} but system limits puts it effectively at {}. Increase LimitNORFILE on systemd or RLIMIT_NOFILE using ulimit.",
+                    settings.max_connections,
+                    effective_max_conn
+                );
+            }
+
             info!("Starting services");
 
             let (proxy_fut, rpc_fut) = (
-                proxy::start(proxy_rt, tcp_listener),
+                proxy::start(proxy_rt, tcp_listener, effective_max_conn),
                 rpc::start(settings.clone(), state.clone(), rpc_listener),
             );
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -1,8 +1,11 @@
 use anyhow::bail;
 use fast_socks5::SocksError;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use thiserror::Error;
-use tokio::{net::TcpStream, sync::RwLock};
+use tokio::{
+    net::TcpStream,
+    sync::{RwLock, Semaphore},
+};
 use tokio_rustls::{
     TlsAcceptor, TlsStream,
     rustls::{
@@ -138,6 +141,7 @@ pub async fn accept_client(
     socket: TcpStream,
     tls_acceptor: Option<TlsAcceptor>,
     ctx: OwnedRequestContext,
+    permit: tokio::sync::OwnedSemaphorePermit,
 ) {
     debug!(subsystem = "proxy_access", "Accepting a proxy connection");
 
@@ -146,6 +150,8 @@ pub async fn accept_client(
 
     tokio::spawn(
         async move {
+            // The permit is dropped when the spawned task completes.
+            let _permit = permit;
             match detect_tls(&socket).await {
                 Ok(true) => {
                     debug!(subsystem = "proxy_access", "TLS detected");
@@ -200,13 +206,57 @@ pub async fn accept_client(
     );
 }
 
-pub async fn start(rt: Arc<ProxyRuntime>, listener: tokio::net::TcpListener) -> anyhow::Result<()> {
+pub async fn start(
+    rt: Arc<ProxyRuntime>,
+    listener: tokio::net::TcpListener,
+    max_connections: usize,
+) -> anyhow::Result<()> {
+    use nix::errno::Errno;
+    use std::io::ErrorKind;
     let tls_acceptor: Option<TlsAcceptor> =
         build_tls_acceptor(&rt.settings, rt.state.clone()).await?;
 
+    let conn_semaphore = Arc::new(Semaphore::new(max_connections.min(Semaphore::MAX_PERMITS)));
+
     loop {
-        let (socket, addr) = listener.accept().await?;
+        let (socket, addr) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                if e.raw_os_error() as Option<i32> == Some(Errno::EMFILE as i32)
+                    || e.raw_os_error() as Option<i32> == Some(Errno::ENFILE as i32)
+                    || e.kind() == ErrorKind::ConnectionAborted
+                    || e.kind() == ErrorKind::Interrupted
+                {
+                    error!(
+                        subsystem = "proxy_errors",
+                        "Transient accept error, backing off: {e}"
+                    );
+
+                    // Give 100ms until you terminate the client connection.
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+
+                    // This is non fatal.
+                    continue;
+                }
+                return Err(e.into());
+            }
+        };
+
+        let permit = match conn_semaphore.clone().try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => {
+                error!(
+                    subsystem = "proxy_errors",
+                    client_address = %addr,
+                    "Connection rejected: proxy at capacity ({max} concurrent connections)",
+                    max = max_connections
+                );
+
+                continue;
+            }
+        };
+
         let ctx = OwnedRequestContext::new(addr);
-        accept_client(rt.clone(), socket, tls_acceptor.clone(), ctx).await;
+        accept_client(rt.clone(), socket, tls_acceptor.clone(), ctx, permit).await;
     }
 }


### PR DESCRIPTION
The accept loop previously propagated every error via ?, so fd exhaustion from a connection flood or self-connect amplification would terminate the entire daemon through the try_join! top-level.

Transient errors are logged with a brief backoff.

Added a configurable setting for max connections (defaults to soft min(16, (RLIMIT_NOFILE - 32) / 32))). New connections are rejected with a connection reset when the proxy is at capacity rather than exhausting further system resources.