### PR TITLE
nix/module: harden for resilience

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -143,6 +143,10 @@ in
         # FileDescriptorStoreMax = 1000;
         # FileDescriptorStorePreserve = "yes";
 
+        # Ensure that Portail restarts in case of failures.
+        Restart = "on-failure";
+        RestartSec = "5s";
+
         PrivateTmp = true;
         PrivateIPC = true;
         ProtectKernelTunables = true;


### PR DESCRIPTION
If Portail fails and crashes, it should be restart upon failure as many
times as necessary.

Signed-off-by: Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>