### PR TITLE
proxy: add handshake timeouts, rename request timeout

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,5 +1,7 @@
 filter-acl-rules-path = "./filter.acl"
-request-timeout = 5
+# Timeouts (all in seconds, defaults shown)
+# handshake-timeout = 15  # Time before the initial bytes are sent.
+connect-timeout = 5 # TCP connect to backend/origin (was request-timeout)
 tcp_nodelay = false
 
 [backends.par01a]
@@ -23,3 +25,6 @@ tls-chain = "./fullchain.pem"
 cacert-file = "./cacert.pem"
 tls-privkey = "./client.key"
 tls-certificate = "./client.pem"
+
+[dns]
+# timeout = 5 # DNS resolution

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -94,7 +94,8 @@ in
 
     services.portail.settings = {
       filter-acl-rules-path = aclRulesFilePath;
-      request-timeout = mkDefault 30;
+      handshake-timeout = mkDefault 15;
+      connect-timeout = mkDefault 30;
       tcp-nodelay = mkDefault false;
       dns.timeout = mkDefault 5;
     };

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -681,7 +681,7 @@ in
           services.portail = {
             enable = true;
             enableAtBoot = true;
-            settings.request-timeout = requestTimeout;
+            settings.connect-timeout = requestTimeout;
             acl.filter.rules.default =
               ''
                 policy hello {

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,9 +183,16 @@ pub struct Settings {
     /// IP address communicated to get the UDP packets back
     pub public_address: Option<std::net::IpAddr>,
 
-    /// Global generic options for proxying
+    /// Timeout for the client to send the initial bytes of a handshake.
+    /// (TLS ClientHello, SOCKS5 greeting, HTTP CONNECT request line).
+    /// Defaults to 15 seconds.
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
-    pub request_timeout: Duration,
+    pub handshake_timeout: Duration,
+
+    /// Timeout for establishing a TCP/UDP connection to a backend or origin.
+    #[serde(alias = "request-timeout")]
+    #[serde_as(as = "serde_with::DurationSeconds<u64>")]
+    pub connect_timeout: Duration,
 
     /// Whether to disable the TCP Nagle optimisation on the proxy side.
     #[serde(default)]

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -337,7 +337,7 @@ async fn handle_http_request(
             }
             BackendSettings::KnownBackend(backend) => {
                 match timeout(
-                    rt.settings.request_timeout,
+                    rt.settings.connect_timeout,
                     connect_to_http_proxy_backend(
                         &backend,
                         &final_address,
@@ -395,7 +395,7 @@ async fn handle_http_request(
                             subsystem = "proxy_access",
                             backend = ?backend,
                             duration_ms = start.elapsed().as_millis(),
-                            configured_timeout_ms = rt.settings.request_timeout.as_millis(),
+                            configured_timeout_ms = rt.settings.connect_timeout.as_millis(),
                             "Backend timed out for HTTP CONNECT, trying next",
                         );
                     }
@@ -450,7 +450,7 @@ async fn handle_http_request(
             &rt.dns,
             authority.host(),
             port,
-            rt.settings.request_timeout,
+            rt.settings.connect_timeout,
             rt.settings.tcp_nodelay,
         )
         .await
@@ -469,7 +469,7 @@ async fn handle_http_request(
                 subsystem = "proxy_errors",
                 address = %final_address,
                 duration_ms = start.elapsed().as_millis(),
-                configured_timeout_ms = rt.settings.request_timeout.as_millis(),
+                configured_timeout_ms = rt.settings.connect_timeout.as_millis(),
                 "Direct connection via Happy Eyeballs failed: {err}",
             ),
         }

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use tokio::{
     net::TcpStream,
     sync::{RwLock, Semaphore},
+    time::timeout,
 };
 use tokio_rustls::{
     TlsAcceptor, TlsStream,
@@ -13,7 +14,7 @@ use tokio_rustls::{
         server::{VerifierBuilderError, WebPkiClientVerifier},
     },
 };
-use tracing::{Instrument, debug, error};
+use tracing::{Instrument, debug, error, warn};
 
 use crate::{
     acl::ast::OwnedConcreteOperand, config::Settings, dns::DnsResolver,
@@ -153,12 +154,15 @@ pub async fn accept_client(
         async move {
             // The permit is dropped when the spawned task completes.
             let _permit = permit;
-            match detect_tls(&socket).await {
-                Ok(true) => {
+            // Wrap TLS detection in a timeout to prevent slowloris attacks
+            // where a client connects and sends nothing.
+            match timeout(rt.settings.handshake_timeout, detect_tls(&socket)).await {
+                Ok(Ok(true)) => {
                     debug!(subsystem = "proxy_access", "TLS detected");
                     if let Some(acceptor) = acceptor {
-                        match acceptor.accept(socket).await {
-                            Ok(tls_stream) => {
+                        match timeout(rt.settings.handshake_timeout, acceptor.accept(socket)).await
+                        {
+                            Ok(Ok(tls_stream)) => {
                                 debug!(
                                     subsystem = "proxy_access",
                                     "Authenticated TLS stream (client certificates)"
@@ -181,8 +185,14 @@ pub async fn accept_client(
                                     error!(subsystem = "proxy_errors", "TLS proxy error: {e:?}");
                                 }
                             }
-                            Err(e) => {
+                            Ok(Err(e)) => {
                                 error!(subsystem = "proxy_errors", "TLS handshake failed: {e:?}");
+                            }
+                            Err(_elapsed) => {
+                                warn!(
+                                    subsystem = "proxy_access",
+                                    "TLS handshake timed out, closing connection",
+                                );
                             }
                         }
                     } else {
@@ -193,7 +203,7 @@ pub async fn accept_client(
                     }
                 }
 
-                Ok(false) => {
+                Ok(Ok(false)) => {
                     debug!(
                         subsystem = "proxy_access",
                         "No TLS detected, serving unauthenticated and plaintext requests",
@@ -209,10 +219,17 @@ pub async fn accept_client(
                     }
                 }
 
-                Err(err) => {
+                Ok(Err(err)) => {
                     error!(
                         subsystem = "proxy_errors",
                         "While detecting the header for TLS, error occurred: {err:?}"
+                    );
+                }
+
+                Err(_elapsed) => {
+                    warn!(
+                        subsystem = "proxy_access",
+                        "TLS detection timed out, closing connection",
                     );
                 }
             }

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -153,10 +153,21 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
 ) -> Result<(), SocksError> {
     let start = Instant::now();
 
-    let (proto, cmd, target_addr) = Socks5ServerProtocol::accept_no_auth(socket)
-        .await?
-        .read_command()
-        .await?;
+    let handshake = Socks5ServerProtocol::accept_no_auth(socket);
+
+    let (proto, cmd, target_addr) = timeout(rt.settings.handshake_timeout, async {
+        let proto = handshake.await?;
+        proto.read_command().await
+    })
+    .await
+    .map_err(|_| {
+        warn!(subsystem = "proxy_access", "SOCKS5 handshake timed out");
+
+        SocksError::Io(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "SOCKS5 handshake timed out",
+        ))
+    })??;
 
     debug!(
         subsystem = "proxy_access",
@@ -317,7 +328,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
             }
             BackendSettings::KnownBackend(backend) => {
                 match timeout(
-                    rt.settings.request_timeout,
+                    rt.settings.connect_timeout,
                     connect_to_backend(&backend, &final_addr, rt.clone()),
                 )
                 .await
@@ -356,7 +367,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                     Err(_) => {
                         debug!(
                             "Backend {} timed out after {:?}, trying the next one",
-                            &backend.target_address, rt.settings.request_timeout
+                            &backend.target_address, rt.settings.connect_timeout
                         );
                         continue;
                     }
@@ -402,7 +413,7 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
                     &rt.dns,
                     &host,
                     port,
-                    rt.settings.request_timeout,
+                    rt.settings.connect_timeout,
                     rt.settings.tcp_nodelay,
                 )
                 .await


### PR DESCRIPTION
Handshake timeouts are important to avoid slowloris-type attacks where a
client attempts to DoS a remote public Portail proxy by saturating all
connection slots.

Signed-off-by: Ryan Lahfa <ryan.lahfa.ext@numerique.gouv.fr>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>