### PR TITLE
Unify backend routing

### DIFF
--- a/src/acl/snapshots/portail__acl__parser__tests__invalid_integer_limits.snap
+++ b/src/acl/snapshots/portail__acl__parser__tests__invalid_integer_limits.snap
@@ -1,6 +1,5 @@
 ---
 source: src/acl/parser.rs
-assertion_line: 980
 expression: result.unwrap_err()
 ---
 error: Failure to parse the ACL rules

--- a/src/acl/snapshots/portail__acl__parser__tests__invalid_route_missing_brace.snap
+++ b/src/acl/snapshots/portail__acl__parser__tests__invalid_route_missing_brace.snap
@@ -1,6 +1,5 @@
 ---
 source: src/acl/parser.rs
-assertion_line: 563
 expression: result.unwrap_err()
 ---
 error: Failure to parse the ACL rules

--- a/src/backend_routing.rs
+++ b/src/backend_routing.rs
@@ -1,0 +1,196 @@
+use std::time::Duration;
+
+use tokio::time::Instant;
+use tracing::{debug, warn};
+
+use crate::{acl::{self, ACLRules}, config::{BackendSettings, KnownBackend}, proxy::{ProxyRuntime, context::LocalRequestContext}};
+
+#[must_use]
+#[derive(Debug, PartialEq, Eq)]
+pub enum ACLDecision {
+    InternalError,
+    Deny,
+    Redirect(http::Uri),
+    Allow,
+}
+
+pub fn assess_request(ctx: &LocalRequestContext<'_>, acl: &ACLRules) -> ACLDecision {
+    let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
+        Ok(assessment) => assessment,
+        Err(failure) => {
+            warn!(
+                subsystem = "proxy_errors",
+                "Failed to evaluate a reequest: {} (context: {:#?})", failure, ctx
+            );
+
+            return ACLDecision::InternalError;
+        }
+    };
+
+    match assessment.action {
+        acl::Action::Deny(_) => ACLDecision::Deny,
+        acl::Action::Redirect(tgt) => ACLDecision::Redirect(tgt),
+        acl::Action::Allow => ACLDecision::Allow,
+    }
+}
+
+/// Builds an ordered backend list from route evaluation, and the default backend.
+///
+/// Callers use [`Vec::pop()`] for highest-priority first. Sets `route.local = false` in the ACL context
+/// so policies can distinguish local exits.
+pub async fn build_backend_chain(
+    rt: &ProxyRuntime,
+    ctx: &mut LocalRequestContext<'_>) -> (Option<Vec<BackendSettings>>, ACLRules) {
+    let mut backends = Vec::with_capacity(1);
+
+    // Clone ACL data out of the read lock and drop the guard immediately.
+    // If you hold the read guard across backend connects, it will starves RPC writers.
+
+    let (backend_specs, acl, default_backend_id) = {
+        let state_guard = rt.state.read().await;
+
+        (state_guard.backends.clone(), state_guard.acl_rules.clone(), state_guard.default_backend.clone())
+    };
+
+    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&backend_specs, &acl.hir) {
+        Ok(routes) => routes,
+        Err(failure) => {
+            warn!(
+                subsystem = "proxy_errors",
+                "Failed to evaluate routes for a request: {} (context: {:#?})",
+                failure, ctx
+            );
+
+            Vec::new()
+        }
+    };
+
+    backends.append(&mut recommended_routes);
+
+    if backends.is_empty() && let Some(ref backend_id) = default_backend_id {
+        let backend = match backend_specs.get(backend_id) {
+            Some(b) => b.to_owned(),
+            None => {
+                warn!(
+                    subsystem = "proxy_errors",
+                    default_backend_id = default_backend_id,
+                    "Default backend ID not found in state, rejecting request"
+                );
+
+                return (None, acl);
+            }
+        };
+
+        backends.push(backend);
+    }
+
+    // High priority is now last.
+    backends.reverse();
+
+    ctx.acl_ctx.insert(
+        "route.local",
+        crate::acl::ast::ConcreteOperand::Boolean(backends.is_empty())
+    );
+
+    (Some(backends), acl)
+}
+
+pub enum BackendOutcome<S, E> {
+    Success(S),
+    Retry,
+    Fatal(E)
+}
+
+impl<S, E> BackendOutcome<S, E> {
+    pub fn from_result_retry(result: Result<S, E>) -> Self {
+        match result {
+            Ok(stream) => BackendOutcome::Success(stream),
+            Err(_) => BackendOutcome::Retry
+        }
+    }
+}
+
+/// Iterate through `backends`, calling `connect_fn` for each with timeout.
+///
+/// Returns `Some(Ok((Stream, backend)))` on first success, `Some(Err(e))` on a fatal error,
+/// or `None` when all backends are exhausted.
+pub async fn try_backends<F, Fut, S, E>(
+    backends: &mut Vec<BackendSettings>,
+    target: &str,
+    connect_timeout: Duration,
+    connect_fn: F
+) -> Option<Result<(S, KnownBackend), E>>
+where 
+    F: Fn(KnownBackend, String) -> Fut,
+    Fut: Future<Output = BackendOutcome<S, E>> {
+        let start = Instant::now();
+
+        while let Some(backend) = backends.pop() {
+            match backend {
+                BackendSettings::UnresolvedBackend => {
+                    tracing::error!(
+                        "An unresolved backend was selected during routing. This should not happen."
+                    );
+
+                    return None;
+                }
+
+                BackendSettings::KnownBackend(known_backend) => {
+                    debug!(
+                        subsystem = "proxy_access",
+                        backend = ?known_backend,
+                        duration_ms = start.elapsed().as_millis(),
+                        "Backend selected for connection routing"
+                    );
+
+                    match tokio::time::timeout(
+                        connect_timeout,
+                        connect_fn(known_backend.clone(), target.to_owned())
+                    ).await {
+                        Ok(BackendOutcome::Success(stream)) => {
+                            debug!(
+                                subsystem = "proxy_access",
+                                backend = ?known_backend,
+                                duration_ms = start.elapsed().as_millis(),
+                                "Connection to upstream backend successful"
+                            );
+
+                            return Some(Ok((stream, known_backend)));
+                        }
+                        Ok(BackendOutcome::Fatal(err)) => {
+                            return Some(Err(err));
+                        }
+                        Ok(BackendOutcome::Retry) => {
+                            debug!(
+                                subsystem = "proxy_access",
+                                backend = ?known_backend,
+                                duration_ms = start.elapsed().as_millis(),
+                                "Backend failed, trying the next one"
+                            );
+
+                            continue;
+                        }
+                        Err(_elapsed) => {
+                            debug!(
+                                subsystem = "proxy_access",
+                                backend = ?known_backend,
+                                duration_ms = start.elapsed().as_millis(),
+                                "Backend timed out, trying the next one"
+                            );
+
+                            continue;
+                        }
+                    }
+                }
+        }
+    }
+
+    None
+}
+
+pub fn mark_direct_exit(ctx: &mut LocalRequestContext<'_>) {
+    ctx.acl_ctx.insert(
+        "route.local",
+        crate::acl::ast::ConcreteOperand::Boolean(true)
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,6 @@
 pub mod acl;
+pub mod backend_routing;
 pub mod config;
+pub mod dns;
+pub mod proxy;
+pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use crate::rpc::fr_gouv_portail_control::{DynamicBackendSpec, GetCurrentBackendO
 use crate::systemd::sd_notify_ready;
 
 mod acl;
+mod backend_routing;
 mod config;
 mod dns;
 mod logging;

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -32,7 +32,7 @@ impl<T: AsyncRead + AsyncWrite> OutboundStreamIo for T {}
 
 type OutboundStream = Box<dyn OutboundStreamIo + Send + Unpin>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 enum InboundHttpProtocol {
     Http1,
     Http2,
@@ -345,7 +345,7 @@ async fn handle_http_request(
                         &backend,
                         &final_address,
                         rt.state.clone(),
-                        &inbound_protocol,
+                        inbound_protocol,
                     ),
                 )
                 .await
@@ -563,7 +563,7 @@ async fn connect_to_http_proxy_backend(
     backend: &KnownBackend,
     final_address: &str,
     state: Arc<RwLock<State>>,
-    inbound_protocol: &InboundHttpProtocol,
+    inbound_protocol: InboundHttpProtocol,
 ) -> Result<OutboundStream, UpstreamConnectError> {
     let socket = TcpStream::connect(backend.target_address).await?;
 

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -104,8 +104,6 @@ pub async fn serve_http1_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
     debug!(subsystem = "proxy_access", "HTTP/1.1 CONNECT request");
     let io = TokioIo::new(stream);
 
-    // TODO: update ctx
-
     http1::Builder::new()
         .serve_connection(
             io,
@@ -128,9 +126,6 @@ pub async fn serve_http2_connect<S: AsyncRead + AsyncWrite + Unpin + Send + 'sta
 ) -> Result<(), ProxyError> {
     debug!(subsystem = "proxy_access", "HTTP/2 CONNECT request");
     let io = TokioIo::new(stream);
-
-    // TODO: update ctx
-    //
 
     // TokioExecutor is a wrapper around tokio::spawn
     // https://docs.rs/hyper-util/latest/src/hyper_util/rt/tokio.rs.html#112
@@ -168,6 +163,14 @@ async fn handle_http_request(
         *resp.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
         return Ok(resp);
     }
+
+    ctx.acl_ctx.insert(
+        "http.version",
+        crate::acl::ast::ConcreteOperand::String(match inbound_protocol {
+            InboundHttpProtocol::Http1 => "h1.1",
+            InboundHttpProtocol::Http2 => "h2"
+        })
+    );
 
     ctx.acl_ctx.insert(
         "proxy.protocol",

--- a/src/proxy/http_connect.rs
+++ b/src/proxy/http_connect.rs
@@ -1,20 +1,23 @@
 use crate::acl::ACLRules;
+use crate::backend_routing;
+use crate::backend_routing::ACLDecision;
+use crate::backend_routing::BackendOutcome;
 use crate::config::BackendSettings;
 use crate::config::KnownBackend;
 use crate::dns::happy_eyeballs_connect;
 use crate::proxy::context::{LocalRequestContext, OwnedRequestContext};
 use crate::proxy::protocols::{ALPN_H2, ALPN_HTTP1_1};
-use crate::proxy::{ProxyError, ProxyRuntime, client_tls};
+use crate::proxy::{client_tls, ProxyError, ProxyRuntime};
 use crate::state::State;
 use bytes::Bytes;
 use http::uri::Authority;
-use http_body_util::{BodyExt, Empty, combinators::BoxBody};
+use http_body_util::{combinators::BoxBody, BodyExt, Empty};
 use hyper::{
-    Method, Request, Response, StatusCode,
     body::Incoming,
     header,
     server::conn::{http1, http2},
     service::service_fn,
+    Method, Request, Response, StatusCode,
 };
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use std::io;
@@ -23,8 +26,8 @@ use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
 use tokio::sync::RwLock;
-use tokio::time::{Instant, timeout};
-use tracing::{Instrument, debug, error, info, warn};
+use tokio::time::{timeout, Instant};
+use tracing::{debug, error, info, warn, Instrument};
 
 /// This is a workaround for the restriction `only auto traits can be used as additional traits in a trait object`
 trait OutboundStreamIo: AsyncRead + AsyncWrite {}
@@ -44,28 +47,18 @@ enum Decision {
     Continue,
 }
 
-fn assess_request(
+fn map_acl_decision(
+    decision: ACLDecision,
     start: Instant,
     target_authority: &Authority,
-    ctx: &LocalRequestContext<'_>,
-    acl: &ACLRules,
 ) -> Result<Decision, hyper::Error> {
-    let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
-        Ok(assessment) => assessment,
-        Err(failure) => {
+    match decision {
+        ACLDecision::InternalError => {
             let mut resp = Response::new(empty_body());
-            warn!(
-                subsystem = "proxy_errors",
-                "Failed to evaluate a request: {} (Context: {:#?})", failure, ctx
-            );
             *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
             return Ok(Decision::TerminateWithResponse(resp));
         }
-    };
-
-    match assessment.action {
-        // FIXME: render the deny template if there's one.
-        crate::acl::Action::Deny(_explain_template) => {
+        ACLDecision::Deny => {
             info!(
                 subsystem = "proxy_access",
                 duration_us = start.elapsed().as_micros(),
@@ -76,7 +69,7 @@ fn assess_request(
 
             Ok(Decision::TerminateWithResponse(resp))
         }
-        crate::acl::Action::Redirect(target) => {
+        ACLDecision::Redirect(target) => {
             info!(
                 subsystem = "proxy_access",
                 original_host = %target_authority.host(),
@@ -87,7 +80,7 @@ fn assess_request(
             Ok(Decision::RedirectDestination(target.to_string()))
         }
 
-        _ => Ok(Decision::Continue),
+        ACLDecision::Allow => Ok(Decision::Continue),
     }
 }
 
@@ -168,8 +161,8 @@ async fn handle_http_request(
         "http.version",
         crate::acl::ast::ConcreteOperand::String(match inbound_protocol {
             InboundHttpProtocol::Http1 => "h1.1",
-            InboundHttpProtocol::Http2 => "h2"
-        })
+            InboundHttpProtocol::Http2 => "h2",
+        }),
     );
 
     ctx.acl_ctx.insert(
@@ -208,22 +201,6 @@ async fn handle_http_request(
 
     let port = target_authority.port_u16().unwrap_or(CONNECT_DEFAULT_PORT);
     let mut final_address = format!("{}:{}", target_authority.host(), port);
-    let mut backends: Vec<BackendSettings> = Vec::with_capacity(1);
-
-    // We evaluate first whether we are allowed then we evaluate routes.
-
-    // Clone ACL data out of the read lock and drop the guard immediately.
-    // If you hold the read guard across backend connects, it will starves RPC writers.
-
-    let (acl, backend_specs, default_backend_id) = {
-        let state_guard = rt.state.read().await;
-
-        (
-            state_guard.acl_rules.clone(),
-            state_guard.backends.clone(),
-            state_guard.default_backend.clone(),
-        )
-    };
 
     debug!(subsystem = "proxy_access", final_address = %final_address,
         "HTTP CONNECT request");
@@ -256,58 +233,19 @@ async fn handle_http_request(
 
     // TODO: how much header information should we render available?
 
-    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&backend_specs, &acl.hir) {
-        Ok(routes) => routes,
-        Err(failure) => {
+    let (mut backends, acl) = match backend_routing::build_backend_chain(&rt, &mut ctx).await {
+        (Some(b), acl) => (b, acl),
+        (None, _) => {
             let mut resp = Response::new(empty_body());
-            warn!(
-                subsystem = "proxy_errors",
-                "Failed to evaluate a request: {} (Context: {:#?})", failure, ctx
-            );
             *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
             return Ok(resp);
         }
     };
-
-    if !recommended_routes.is_empty() {
-        backends.append(&mut recommended_routes);
-    }
-
-    if backends.is_empty()
-        && let Some(ref backend_id) = default_backend_id
-    {
-        let backend = match backend_specs.get(backend_id) {
-            Some(b) => b.to_owned(),
-            None => {
-                warn!(
-                    subsystem = "proxy_errors",
-                    "Default backend {backend_id} not found in state, rejecting request",
-                );
-
-                let mut resp = Response::new(empty_body());
-                *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                return Ok(resp);
-            }
-        };
-
-        backends.push(backend);
-    }
-
-    backends.reverse();
-
-    if backends.is_empty() {
-        ctx.acl_ctx.insert(
-            "route.local",
-            crate::acl::ast::ConcreteOperand::Boolean(true),
-        );
-    } else {
-        ctx.acl_ctx.insert(
-            "route.local",
-            crate::acl::ast::ConcreteOperand::Boolean(false),
-        );
-    }
-
-    match assess_request(start, target_authority, &ctx, &acl)? {
+    match map_acl_decision(
+        backend_routing::assess_request(&ctx, &acl),
+        start,
+        target_authority,
+    )? {
         Decision::TerminateWithResponse(resp) => return Ok(resp),
         Decision::RedirectDestination(target) => final_address = target,
         Decision::Continue => {}
@@ -321,48 +259,34 @@ async fn handle_http_request(
 
     let mut stream: Option<OutboundStream> = None;
     let start = Instant::now();
-    for backend in backends {
-        debug!(
-            subsystem = "proxy_access",
-            address = %final_address,
-            backend = ?backend,
-            "Backend selected for HTTP CONNECT"
-        );
-        match backend {
-            BackendSettings::UnresolvedBackend => {
-                // TODO: keep the IDs to print them here.
-                tracing::error!(
-                    "An unresolved backend was selected during HTTP CONNECT routing. This should not happen, rejecting the request."
-                );
-                let mut resp = Response::new(empty_body());
-                *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-                return Ok(resp);
-            }
-            BackendSettings::KnownBackend(backend) => {
-                match timeout(
-                    rt.settings.connect_timeout,
-                    connect_to_http_proxy_backend(
-                        &backend,
-                        &final_address,
-                        rt.state.clone(),
-                        inbound_protocol,
-                    ),
+
+    let backend_result = backend_routing::try_backends(
+        &mut backends,
+        &final_address,
+        rt.settings.connect_timeout,
+        |backend, target| {
+            let state = rt.state.clone();
+            async move {
+                match connect_to_http_proxy_backend(
+                    &backend,
+                    &target,
+                    state,
+                    inbound_protocol,
                 )
                 .await
                 {
-                    Ok(Ok(upstream)) => {
+                    Ok(upstream) => {
                         info!(
                             subsystem = "proxy_access",
-                            address = %final_address,
+                            address = %target,
                             backend = ?backend,
                             duration_ms = start.elapsed().as_millis(),
                             "Stream established to upstream backend"
                         );
 
-                        stream = Some(upstream);
-                        break;
+                        BackendOutcome::Success(upstream)
                     }
-                    Ok(Err(UpstreamConnectError::UpstreamResponse(resp))) => {
+                    Err(UpstreamConnectError::UpstreamResponse(resp)) => {
                         // Send back the client errors.
                         if resp.status().is_client_error() {
                             info!(
@@ -373,7 +297,7 @@ async fn handle_http_request(
                                 "Backend returned a non-200 client error for HTTP CONNECT, returning it to the client and terminating the request"
                             );
 
-                            return Ok(resp.map(|b| b.boxed()));
+                            BackendOutcome::Fatal(resp.map(|b| b.boxed()))
                         } else {
                             info!(
                                 subsystem = "proxy_access",
@@ -382,9 +306,11 @@ async fn handle_http_request(
                                 status = %resp.status(),
                                 "Backend returned a non-200 response for HTTP CONNECT, trying next as it's not a client error"
                             );
+
+                            BackendOutcome::Retry
                         }
                     }
-                    Ok(Err(UpstreamConnectError::IO(err))) => {
+                    Err(UpstreamConnectError::IO(err)) => {
                         info!(
                             subsystem = "proxy_access",
                             backend = ?backend,
@@ -392,29 +318,32 @@ async fn handle_http_request(
                             "Backend failed for HTTP CONNECT: {}, trying next",
                             err
                         );
-                    }
-                    Err(_) => {
-                        info!(
-                            subsystem = "proxy_access",
-                            backend = ?backend,
-                            duration_ms = start.elapsed().as_millis(),
-                            configured_timeout_ms = rt.settings.connect_timeout.as_millis(),
-                            "Backend timed out for HTTP CONNECT, trying next",
-                        );
+
+                        BackendOutcome::Retry
                     }
                 }
             }
+        }).await;
+
+    match backend_result {
+        Some(Ok((upstream, _backend))) => {
+            stream = Some(upstream);
         }
+        Some(Err(resp)) => {
+            return Ok(resp);
+        }
+        None => {}
     }
 
     if stream.is_none() {
         // At this point, we need to re-assess if the request can go through.
-        ctx.acl_ctx.insert(
-            "route.local",
-            crate::acl::ast::ConcreteOperand::Boolean(true),
-        );
+        backend_routing::mark_direct_exit(&mut ctx);
 
-        match assess_request(start, target_authority, &ctx, &acl)? {
+        match map_acl_decision(
+            backend_routing::assess_request(&ctx, &acl),
+            start,
+            target_authority,
+        )? {
             Decision::TerminateWithResponse(resp) => return Ok(resp),
             Decision::RedirectDestination(target) => final_address = target,
             _ => {}

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 mod client_tls;
-mod context;
+pub mod context;
 mod http_connect;
 mod protocols;
 mod socks5;

--- a/src/proxy/socks5.rs
+++ b/src/proxy/socks5.rs
@@ -4,26 +4,27 @@ use std::{
 };
 
 use fast_socks5::{
-    ReplyError, Socks5Command, SocksError,
     client::Socks5Stream,
     server::Socks5ServerProtocol,
     util::target_addr::{AddrError, TargetAddr},
+    ReplyError, Socks5Command, SocksError,
 };
 use tokio::{
     io::{AsyncRead, AsyncWrite},
     net::TcpStream,
-    time::{Instant, timeout},
+    time::{timeout, Instant},
 };
 use tokio_rustls::TlsStream;
 use tracing::{debug, info, warn};
 
 use crate::{
     acl::ACLRules,
+    backend_routing::{self, ACLDecision, BackendOutcome},
     config::{BackendSettings, KnownBackend},
-    dns::{DnsError, HappyEyeballsError, happy_eyeballs_connect},
+    dns::{happy_eyeballs_connect, DnsError, HappyEyeballsError},
     proxy::{
-        ProxyRuntime,
         context::{LocalRequestContext, OwnedRequestContext, TargetContext},
+        ProxyRuntime,
     },
 };
 
@@ -39,26 +40,17 @@ enum Decision {
     Continue,
 }
 
-fn assess_request(
+fn map_acl_decision(
+    decision: ACLDecision,
     start: Instant,
     target_context: &TargetContext,
-    ctx: &LocalRequestContext<'_>,
-    acl: &ACLRules,
 ) -> Result<Decision, fast_socks5::SocksError> {
-    let assessment = match ctx.acl_ctx.evaluate_request(&acl.hir) {
-        Ok(assessment) => assessment,
-        Err(failure) => {
-            warn!(
-                subsystem = "proxy_errors",
-                "Failed to evaluate a request: {} (Context: {:#?})", failure, ctx
-            );
+    match decision {
+        ACLDecision::InternalError => {
             return Ok(Decision::TerminateWithError(ReplyError::GeneralFailure));
         }
-    };
 
-    match assessment.action {
-        // FIXME: render the deny template if there's one.
-        crate::acl::Action::Deny(_explain_template) => {
+        ACLDecision::Deny => {
             info!(
                 subsystem = "proxy_access",
                 target_context = ?target_context,
@@ -70,7 +62,8 @@ fn assess_request(
                 ReplyError::ConnectionNotAllowed,
             ))
         }
-        crate::acl::Action::Redirect(target) => {
+
+        ACLDecision::Redirect(target) => {
             info!(
                 subsystem = "proxy_access",
                 target_context = ?target_context,
@@ -90,7 +83,7 @@ fn assess_request(
             )))
         }
 
-        _ => Ok(Decision::Continue),
+        ACLDecision::Allow => Ok(Decision::Continue),
     }
 }
 
@@ -228,72 +221,19 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
         "SOCKS5 command allowed"
     );
 
-    let mut backends: Vec<BackendSettings> = Vec::with_capacity(1);
-
-    // Clone ACL data out of the read lock and drop the guard immediately.
-    // If you hold the read guard across backend connects, it will starves RPC writers.
-
-    let (acl, backend_specs, default_backend_id) = {
-        let state_guard = rt.state.read().await;
-
-        (
-            state_guard.acl_rules.clone(),
-            state_guard.backends.clone(),
-            state_guard.default_backend.clone(),
-        )
-    };
-
-    // We evaluate first the routes as it can influence the ACL in case of a local exit.
-    let mut recommended_routes = match ctx.acl_ctx.evaluate_routes(&backend_specs, &acl.hir) {
-        Ok(routes) => routes,
-        Err(failure) => {
+    let (mut backends, acl) = match backend_routing::build_backend_chain(&rt, &mut ctx).await {
+        (Some(b), acl) => (b, acl),
+        (None, _) => {
             proto.reply_error(&ReplyError::GeneralFailure).await?;
-            warn!(
-                subsystem = "proxy_errors",
-                "Failed to evaluate routes for a request: {} (Context: {:#?})", failure, ctx
-            );
             return Ok(());
         }
     };
 
-    if !recommended_routes.is_empty() {
-        backends.append(&mut recommended_routes);
-    }
-
-    if backends.is_empty()
-        && let Some(ref backend_id) = default_backend_id
-    {
-        let backend = match backend_specs.get(backend_id) {
-            Some(b) => b.to_owned(),
-            None => {
-                warn!(
-                    subsystem = "proxy_errors",
-                    "Default backend {backend_id} not found in state, rejecting request",
-                );
-
-                proto.reply_error(&ReplyError::GeneralFailure).await?;
-                return Ok(());
-            }
-        };
-
-        backends.push(backend);
-    }
-
-    backends.reverse();
-
-    if backends.is_empty() {
-        ctx.acl_ctx.insert(
-            "route.local",
-            crate::acl::ast::ConcreteOperand::Boolean(true),
-        );
-    } else {
-        ctx.acl_ctx.insert(
-            "route.local",
-            crate::acl::ast::ConcreteOperand::Boolean(false),
-        );
-    }
-
-    match assess_request(start, &target_context, &ctx, &acl)? {
+    match map_acl_decision(
+        backend_routing::assess_request(&ctx, &acl),
+        start,
+        &target_context,
+    )? {
         Decision::TerminateWithError(error) => {
             proto.reply_error(&error).await?;
             return Ok(());
@@ -309,71 +249,44 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
     );
 
     let start = Instant::now();
-    // Either, we route to another backend or we do the SOCKS5 proxying ourselves.
-    while let Some(backend) = backends.pop() {
-        debug!(
-            subsystem = "proxy_access",
-            backend = ?backend,
-            duration_ms = start.elapsed().as_millis(),
-            "Backend selected for connection routing"
-        );
-        match backend {
-            BackendSettings::UnresolvedBackend => {
-                // TODO: keep the IDs to print them here.
-                tracing::error!(
-                    "An unresolved backend was selected during SOCKS5 routing. This should not happen, rejecting the request."
-                );
-                proto.reply_error(&ReplyError::GeneralFailure).await?;
-                return Ok(());
-            }
-            BackendSettings::KnownBackend(backend) => {
-                match timeout(
-                    rt.settings.connect_timeout,
-                    connect_to_backend(&backend, &final_addr, rt.clone()),
+    match backend_routing::try_backends(
+        &mut backends,
+        &final_addr.to_string(),
+        rt.settings.connect_timeout,
+        |backend, _target| {
+            let rt = Arc::clone(&rt);
+            let final_addr = final_addr.clone();
+            async move {
+                BackendOutcome::from_result_retry(
+                    connect_to_backend(&backend, &final_addr, rt).await,
                 )
-                .await
-                {
-                    Ok(Ok(stream)) => {
-                        debug!(
-                            subsystem = "proxy_access",
-                            backend = ?backend,
-                            duration_ms = start.elapsed().as_millis(),
-                            "Connection to upstream backend successful"
-                        );
-
-                        let start = Instant::now();
-
-                        route_to_backend(stream, proto).await?;
-
-                        debug!(
-                            subsystem = "proxy_access",
-                            duration_ms = start.elapsed().as_millis(),
-                            "SOCKS5 request finished"
-                        );
-
-                        return Ok(());
-                    }
-
-                    Ok(Err(err)) => {
-                        debug!(
-                            subsystem = "proxy_errors",
-                            backend = ?backend,
-                            "Backend failed to route the request: {err}, trying the next one",
-                        );
-
-                        continue;
-                    }
-
-                    Err(_) => {
-                        debug!(
-                            "Backend {} timed out after {:?}, trying the next one",
-                            &backend.target_address, rt.settings.connect_timeout
-                        );
-                        continue;
-                    }
-                }
             }
+        },
+    )
+    .await
+    {
+        Some(Ok((stream, _backend))) => {
+            let start = Instant::now();
+            route_to_backend(stream, proto).await?;
+            debug!(
+                subsystem = "proxy_access",
+                duration_ms = start.elapsed().as_millis(),
+                "SOCKS5 request finished"
+            );
+
+            return Ok(());
         }
+
+        Some(Err(err)) => {
+            warn!(
+                subsystem = "proxy_errors",
+                err = %err,
+                "BUG: SOCKS5 connection should never produces fatal outcomes"
+            );
+        }
+
+        // Move on to direct exit.
+        None => {}
     }
 
     // Direct exit: if we get there, this means that we did not have any backend at all.
@@ -386,11 +299,12 @@ pub async fn serve_socks5<S: AsyncRead + Unpin + AsyncWrite>(
 
         let start = Instant::now();
 
-        ctx.acl_ctx.insert(
-            "route.local",
-            crate::acl::ast::ConcreteOperand::Boolean(true),
-        );
-        match assess_request(start, &target_context, &ctx, &acl)? {
+        backend_routing::mark_direct_exit(&mut ctx);
+        match map_acl_decision(
+            backend_routing::assess_request(&ctx, &acl),
+            start,
+            &target_context,
+        )? {
             Decision::TerminateWithError(error) => {
                 proto.reply_error(&error).await?;
                 return Ok(());


### PR DESCRIPTION
In the past, backend routing was duplicated in the SOCKS5/HTTP CONNECT codepath. This was technical debt. To simplify some of the future changes regarding response injections, we perform the surgery and unify it.

I went for fn closure to express the exact connect logic to avoid formalizing it too hard. If this is too much of a performance issue, we can revisit.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>