### PR TITLE
Render basic (customizable) error pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "askama"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf825125edd887a019d0a3a837dcc5499a68b0d034cc3eb594070c3e18addc"
+dependencies = [
+ "askama_macros",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1c7065972a130eafa84215f21352ae15b4a7393da48c1f5e103904490736738"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "glob",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e23b1d2c4bd39a41971f6124cef4cc6fd0540913ecb90919b69ab3bbe44ae1a"
+dependencies = [
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db09fde9143e7ac4513358fb32ee32847125b63b18ea715afd487956da715da"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +248,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -785,6 +847,12 @@ dependencies = [
  "r-efi",
  "rand_core",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "h2"
@@ -1545,6 +1613,7 @@ version = "0.1.0"
 dependencies = [
  "annotate-snippets",
  "anyhow",
+ "askama",
  "bytes",
  "clap",
  "criterion",
@@ -1740,6 +1809,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing-appender = "0.2.5"
 hickory-resolver = { version = "^0.26", features = ["tokio"] }
 futures = "0.3.33"
 tokio-util = "0.7.19"
+askama = "0.16.0"
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports"] }

--- a/src/acl/ast.rs
+++ b/src/acl/ast.rs
@@ -45,6 +45,8 @@ pub enum Action {
     Allow,
     Deny(Option<PathBuf>),
     Redirect(Uri),
+    /// Select a template for explanation (explain ACL only).
+    Explain(String),
 }
 
 #[derive(Debug, Clone)]

--- a/src/acl/hir.rs
+++ b/src/acl/hir.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 
 use thiserror::Error;
 
-use crate::acl::Action;
 use crate::acl::ast;
+use crate::acl::Action;
 use crate::config::BackendSettings;
 
 #[derive(Debug, Clone)]
@@ -29,6 +29,14 @@ pub struct ACLHir {
     pub(crate) policies: Vec<PolicyDefinition>,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum AclContext {
+    /// Filter ACL: allow, deny, redirect
+    Filter,
+    /// Explain ACL: explain.
+    Explain,
+}
+
 #[derive(Debug, Error)]
 pub enum TransformationError {
     #[error("Route block '{0}' has no backend to route to")]
@@ -43,6 +51,10 @@ pub enum TransformationError {
     DuplicateAttributeInRoute(&'static str, String),
     #[error("In policy block '{1}', attribute '{0}' occurs more than once")]
     DuplicateAttributeInPolicy(&'static str, String),
+    #[error("Action 'explain' is not valid in filter ACL context (policy: '{0}')")]
+    ExplainActionInFilterContext(String),
+    #[error("Action '{1}' is not valid in explain ACL context (policy '{0}')")]
+    InvalidActionInExplainContext(String, String),
 }
 
 fn route_to_hir(
@@ -101,6 +113,7 @@ fn route_to_hir(
 
 fn policy_to_hir<'s>(
     policy: ast::PolicyBlock<'s>,
+    context: AclContext,
 ) -> Result<PolicyDefinition, TransformationError> {
     let mut when = None;
     let mut require = None;
@@ -139,6 +152,25 @@ fn policy_to_hir<'s>(
     let action =
         action.ok_or_else(|| TransformationError::MissingAction(policy.name.to_owned()))?;
 
+    match context {
+        AclContext::Filter => {
+            if matches!(action, ast::Action::Explain(_)) {
+                return Err(TransformationError::ExplainActionInFilterContext(
+                    policy.name.to_owned(),
+                ));
+            }
+        }
+        AclContext::Explain => match action {
+            ast::Action::Explain(_) => {}
+            _ => {
+                return Err(TransformationError::InvalidActionInExplainContext(
+                    format!("{:?}", action),
+                    policy.name.to_owned(),
+                ));
+            }
+        },
+    }
+
     Ok(PolicyDefinition {
         name: policy.name.to_owned(),
         when,
@@ -151,9 +183,10 @@ fn policy_to_hir<'s>(
 /// ready for quick evaluation.
 ///
 /// Semantic validation occurs during this transformation pass.
-pub fn ast_to_hir<'s>(
+pub fn ast_to_hir_contextualized<'s>(
     ast: ast::ACLAst<'s>,
     backends: &HashMap<String, BackendSettings>,
+    context: AclContext,
 ) -> Result<ACLHir, TransformationError> {
     let mut route_names = HashSet::new();
     let mut policy_names = HashSet::new();
@@ -164,6 +197,11 @@ pub fn ast_to_hir<'s>(
     for entry in ast.entries {
         match entry {
             ast::ACLEntry::Route(route) => {
+                if matches!(context, AclContext::Explain) {
+                    // TODO: Warn on this.
+                    continue;
+                }
+
                 let hir = route_to_hir(route, backends)?;
                 if route_names.contains(hir.name.as_str()) {
                     return Err(TransformationError::DuplicateBlock(hir.name, "route"));
@@ -174,7 +212,7 @@ pub fn ast_to_hir<'s>(
             }
 
             ast::ACLEntry::Policy(policy) => {
-                let hir = policy_to_hir(policy)?;
+                let hir = policy_to_hir(policy, context)?;
                 if policy_names.contains(hir.name.as_str()) {
                     return Err(TransformationError::DuplicateBlock(hir.name, "policy"));
                 }
@@ -196,6 +234,13 @@ mod tests {
     use crate::config::{BackendSettings, ServerName};
     use insta::assert_debug_snapshot;
     use std::collections::HashMap;
+
+    pub fn ast_to_hir<'s>(
+        ast: ast::ACLAst<'s>,
+        backends: &HashMap<String, BackendSettings>,
+    ) -> Result<ACLHir, TransformationError> {
+        ast_to_hir_contextualized(ast, backends, AclContext::Filter)
+    }
 
     // TODO: check for missing backends
 
@@ -405,6 +450,46 @@ mod tests {
         assert!(matches!(
             result,
             Err(TransformationError::MissingBackendInSettings(_))
+        ));
+    }
+
+    #[test]
+    fn reject_explain_in_filter() {
+        let ast = ast::ACLAst {
+            entries: vec![ast::ACLEntry::Policy(ast::PolicyBlock {
+                name: "policy",
+                attributes: vec![ast::PolicyAttribute::Action(Action::Explain(
+                    "deny-employees.html".to_string(),
+                ))],
+            })],
+        };
+
+        let settings = settings_with_backends(&[]);
+
+        let result = ast_to_hir_contextualized(ast, &settings, AclContext::Filter);
+
+        assert!(matches!(
+            result,
+            Err(TransformationError::ExplainActionInFilterContext(_))
+        ));
+    }
+
+    #[test]
+    fn reject_allow_in_explain() {
+        let ast = ast::ACLAst {
+            entries: vec![ast::ACLEntry::Policy(ast::PolicyBlock {
+                name: "policy",
+                attributes: vec![ast::PolicyAttribute::Action(Action::Allow)],
+            })],
+        };
+
+        let settings = settings_with_backends(&[]);
+
+        let result = ast_to_hir_contextualized(ast, &settings, AclContext::Explain);
+
+        assert!(matches!(
+            result,
+            Err(TransformationError::InvalidActionInExplainContext(_, _))
         ));
     }
 }

--- a/src/acl/mod.rs
+++ b/src/acl/mod.rs
@@ -7,11 +7,11 @@ use std::path::Path;
 
 pub use ast::Action;
 pub use evaluator::{EvaluationContext, OwnedEvaluationContext};
-pub use hir::{ACLHir, ast_to_hir};
+pub use hir::{ast_to_hir_contextualized, ACLHir};
 pub use parser::parse_into_ast;
 use thiserror::Error;
 
-use crate::config::Settings;
+use crate::{acl::hir::AclContext, config::Settings};
 
 #[derive(Debug, Clone)]
 pub struct ACLRules {
@@ -33,14 +33,19 @@ pub enum LoadError {
 pub fn load_rules_from_file<P: AsRef<Path>>(
     path: P,
     settings: &Settings,
+    context: AclContext,
 ) -> Result<ACLRules, LoadError> {
     let acl_contents = std::fs::read_to_string(path)?;
-    load_rules_from_str(&acl_contents, settings)
+    load_rules_from_str(&acl_contents, settings, context)
 }
 
-pub fn load_rules_from_str(contents: &str, settings: &Settings) -> Result<ACLRules, LoadError> {
+pub fn load_rules_from_str(
+    contents: &str,
+    settings: &Settings,
+    context: AclContext,
+) -> Result<ACLRules, LoadError> {
     let ast = parse_into_ast(contents)?;
-    let hir = ast_to_hir(ast, &settings.backends)?;
+    let hir = ast_to_hir_contextualized(ast, &settings.backends, context)?;
 
     Ok(ACLRules { hir })
 }

--- a/src/acl/parser.rs
+++ b/src/acl/parser.rs
@@ -2,16 +2,16 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 use regex::Regex;
-use winnow::ModalResult;
 use winnow::ascii::{digit1, multispace1};
 use winnow::combinator::{alt, cut_err, dispatch, fail, opt, preceded, repeat, separated};
 use winnow::error::{
     ContextError, ErrMode, FromExternalError, ParseError, StrContext, StrContextValue,
 };
 use winnow::token::take;
+use winnow::ModalResult;
 use winnow::{
-    Parser, Result, ascii::multispace0, combinator::delimited, error::ParserError,
-    token::take_while,
+    ascii::multispace0, combinator::delimited, error::ParserError, token::take_while, Parser,
+    Result,
 };
 
 use crate::acl::ast::{
@@ -235,9 +235,11 @@ fn action_statement(input: &mut &str) -> ModalResult<Action> {
             ),
         )
         .map(|s| Action::Redirect(s.to_owned())),
+        preceded("explain", cut_err(preceded(multispace1, string_literal)))
+            .map(|s| Action::Explain(s.to_owned())),
         fail.context(StrContext::Label("action statement"))
             .context(StrContext::Expected(StrContextValue::Description(
-                "allow, deny [explain-template=] or redirect",
+                "allow, deny [explain-template=], redirect or explain",
             ))),
     ))
     .context(StrContext::Label("action statement"))
@@ -755,6 +757,21 @@ mod tests {
         let result = parse_into_ast(&mut input);
 
         assert_debug_snapshot!("valid_expression_precedence", result.unwrap());
+    }
+
+    #[test]
+    fn parse_valid_explain_action() {
+        let mut input = r#"
+            policy explain_policy {
+                when user.authenticated == true
+                action explain "deny-employee.html"
+            }
+        "#;
+
+        let rules = parse_into_ast(&mut input).unwrap();
+        assert_eq!(rules.entries.len(), 1);
+
+        assert_debug_snapshot!("explain_action", rules);
     }
 
     #[test]

--- a/src/acl/snapshots/portail__acl__parser__tests__explain_action.snap
+++ b/src/acl/snapshots/portail__acl__parser__tests__explain_action.snap
@@ -1,0 +1,34 @@
+---
+source: src/acl/parser.rs
+expression: rules
+---
+ACLAst {
+    entries: [
+        Policy(
+            PolicyBlock {
+                name: "explain_policy",
+                attributes: [
+                    When(
+                        Comparison(
+                            DottedIdentifier(
+                                [
+                                    "user",
+                                    "authenticated",
+                                ],
+                            ),
+                            Eq,
+                            Boolean(
+                                true,
+                            ),
+                        ),
+                    ),
+                    Action(
+                        Explain(
+                            "deny-employee.html",
+                        ),
+                    ),
+                ],
+            },
+        ),
+    ],
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
 
+use crate::acl::hir::AclContext;
 use crate::logging::LogPreset;
 use crate::rpc::fr_gouv_portail_control::{DynamicBackendSpec, GetCurrentBackendOutput};
 use crate::systemd::sd_notify_ready;
@@ -364,7 +365,7 @@ async fn main() -> Result<()> {
             )
             .into_owned();
             let settings: Arc<config::Settings> = Arc::new(config::init(&config));
-            match acl::load_rules_from_str(contents.as_str(), &settings) {
+            match acl::load_rules_from_str(contents.as_str(), &settings, AclContext::Filter) {
                 Ok(rules) => info!(
                     n_policies = %rules.hir.policies.len(),
                     n_routes = %rules.hir.routes.len(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod proxy;
 mod rpc;
 mod state;
 mod systemd;
+mod templates;
 
 use rpc::fr_gouv_portail_control::Control;
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,7 +13,7 @@ use tokio_rustls::rustls::{
 };
 use tracing::{info, warn};
 
-use crate::config::{BackendSettings, Settings};
+use crate::{acl::hir::AclContext, config::{BackendSettings, Settings}};
 use thiserror::Error;
 
 pub struct ServerCertificates<'a> {
@@ -137,7 +137,7 @@ impl State {
     #[allow(dead_code)]
     pub fn reload_acl_rules(&mut self, settings: &Settings) {
         if let Some(ref acl_rules_path) = settings.filter_acl_rules_path {
-            let new_acl = crate::acl::load_rules_from_file(acl_rules_path, settings);
+            let new_acl = crate::acl::load_rules_from_file(acl_rules_path, settings, AclContext::Filter);
 
             match new_acl {
                 Ok(new_acl) => {
@@ -171,6 +171,7 @@ pub fn init(settings: &Settings) -> Result<State, InitError> {
                 .clone()
                 .ok_or(InitError::MissingACLFile)?,
             settings,
+            AclContext::Filter
         )?,
         root_store: None,
         client_cert_resolver: None,

--- a/src/templates/default-deny.html
+++ b/src/templates/default-deny.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8"><title>Access Denied — Portail</title>
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 600px; margin: 4rem auto; padding: 0 1rem; }
+      code { background: #eee; padding: 0.1em 0.3em; border-radius: 3px; }
+    </style>
+  </head>
+  <body>
+    <h1>Access Denied</h1>
+    <p>Your request was denied.</p>
+    <p><small>Reference: <code>{{ trace_id }}</code></small></p>
+  </body>
+</html>

--- a/src/templates/defaults.rs
+++ b/src/templates/defaults.rs
@@ -1,0 +1,35 @@
+///! Built-in default templates using Askama
+///!
+///! All variables are HTML-escaped by default.
+use askama::Template;
+
+/// Minimal deny page, safe for unknown users.
+/// You can replace it with your hotline or support page.
+#[derive(Template)]
+#[template(path = "./minimal-deny.html")]
+struct DenyGeneric;
+
+/// Default deny page, includes trace ID for support reference.
+#[derive(Template)]
+#[template(path = "./default-deny.html")]
+struct DenyDefault {
+    trace_id: uuid::Uuid,
+}
+
+pub fn render_builtin(name: &str) -> String {
+    let trace_id = "";
+    match name {
+        "deny-default" => DenyDefault {
+            trace_id
+        }.render()
+        .unwrap_or_else(|e| {
+            tracing::warn!("Failed to render deny-default template: {e}");
+            format!("Access Denied. Reference: {}", trace_id);
+        }),
+
+        _ => DenyGeneric.render().unwrap_or_else(|e| {
+            tracing::warn!("Failed to render deny-generic template: {e}");
+            "Access Denied".into()
+        }
+    }
+}

--- a/src/templates/minimal-deny.html
+++ b/src/templates/minimal-deny.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Access Denied</title>
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 600px; margin: 4rem auto; padding: 0 1rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Access Denied</h1>
+    <p>You don't have permission to access this resource.</p>
+  </body>
+</html>

--- a/src/templates/mod.rs
+++ b/src/templates/mod.rs
@@ -1,0 +1,53 @@
+//! Template rendering for error and explain pages.
+//!
+//! Templates use a simple `{{ var }}` syntax, similar to Jinja2. All variables are HTML-escaped
+//! except `downstream_body`, which is injected as raw HTML (trusted upstream proxy contents).
+
+use std::{collections::HashMap, path::Path};
+
+use crate::acl::ast::OwnedConcreteOperand;
+
+pub mod defaults;
+
+#[derive(Debug, Clone)]
+pub struct TemplateContext {
+    pub trace_id: uuid::Uuid,
+    pub client_address: String,
+    pub timestamp: String,
+    pub variables: HashMap<String, OwnedConcreteOperand>,
+}
+
+pub enum TemplateScenario {
+    HttpCode(hyper::StatusCode),
+    FilterACL {
+        action: crate::acl::Action,
+        filter_template: Option<String>,
+        explain_template: Option<String>,
+    },
+}
+
+pub struct TemplateRegistry {
+    overrides: HashMap<String, String>,
+}
+
+impl TemplateRegistry {
+    //pub fn new<P: AsRef<Path>>(template_dir: Option<P>) -> Self {
+    //    // Read overrides if necessary.
+    //}
+
+    //fn resolve(&self, scenario: &TemplateScenario) -> Option<&str> {
+    //    match scenario {
+    //        TemplateScenario::HttpCode(status_code) => {}
+    //        TemplateScenario::FilterACL {
+    //            action,
+    //            filter_template,
+    //            explain_template,
+    //        } => explain_template
+    //            .as_ref()
+    //            .map(String::as_str)
+    //            .or(filter_template.as_ref().map(String::as_str)),
+    //    }
+    //}
+
+    //pub fn render(&self, scenario: TemplateScenario, ctx: &TemplateContext) -> String {}
+}


### PR DESCRIPTION
_This is a draft._

Fixes #128.

This provides a way for operators to present customizable error pages in case of ACL rejections, internal errors, HTTP upstream errors and so on.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>