### PR TITLE
Support logrotate

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -127,6 +127,24 @@ in
       };
     };
 
+    services.logrotate.settings = {
+      "/var/log/portail" = {
+        files = [ "/var/log/portail/*.log" ];
+        frequency = "weekly";
+        rotate = 4;
+        compress = true;
+        delaycompress = true;
+        missingok = true;
+        notifempty = true;
+        nocreate = true;
+        sharedscripts = true;
+        # Tell Portail to rotate its log files.
+        postrotate = ''
+          systemctl kill -s HUP portail.service || true
+        '';
+      };
+    };
+
     systemd.services.portail = {
       description = "Portail access proxy";
       wantedBy = mkIf cfg.enableAtBoot [ "multi-user.target" ];

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -1025,4 +1025,41 @@ in
         ), "Unexpected HTTP CONNECT result: {}".format(json.dumps(result))
       '';
     };
+
+  # Sends SIGHUP to portail after simulating a logrotate nocreate rename.
+  # Verifies the daemon reopen its log files without crashing.
+  sighup-reopen = pkgs.testers.nixosTest {
+    name = "portail-sighup";
+    nodes = {
+      node = { ... }: {
+        imports = [ ../module.nix portailEnv ];
+
+        services.portail = {
+          enable = true;
+          enableAtBoot = true;
+          acl.filter.rules.default = ''
+            policy allow_all {
+              action allow
+            }
+          '';
+        };
+      };
+    };
+    testScript = ''
+      start_all()
+
+      node.wait_for_unit("portail.service")
+
+      node.wait_until_succeeds("test -f /var/log/portail/access.log")
+      node.wait_until_succeeds("test -f /var/log/portail/error.log")
+      node.wait_until_succeeds("test -f /var/log/portail/rpc.log")
+
+      node.succeed("mv /var/log/portail/access.log /var/log/portail/access.log.1")
+      node.succeed("systemctl kill -s HUP portail.service")
+
+      node.wait_until_succeeds("test -f /var/log/portail/access.log")
+      # Portail must not die.
+      node.succeed("systemctl is-active portail.service")
+    '';
+  };
 }

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -11,6 +11,8 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
 };
 
+mod writer;
+
 #[derive(Debug, Clone)]
 pub enum LogFormat {
     #[allow(dead_code)]

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -11,6 +11,8 @@ use tracing_subscriber::{
     util::SubscriberInitExt,
 };
 
+use crate::logging::writer::SharedFileWriter;
+
 mod writer;
 
 #[derive(Debug, Clone)]
@@ -341,6 +343,7 @@ fn preset_to_config(preset: LogPreset) -> HashMap<Subsystem, LogConfig> {
 fn create_layer_for_route(
     subsystem: Subsystem,
     route: &LogRoute,
+    file_handles: &mut Vec<SharedFileWriter>,
 ) -> Result<(Box<dyn Layer<Registry> + Send + Sync>, WorkerGuard), std::io::Error> {
     let (writer, guard) = match &route.output {
         LogOutput::Stdout => tracing_appender::non_blocking(std::io::stdout()),
@@ -348,11 +351,12 @@ fn create_layer_for_route(
         LogOutput::File(path) => {
             // Log files may contain all users' traffic destinations.
             // It MUST never be world-readable.
-            let file = OpenOptions::new()
-                .append(true)
-                .create(true)
-                .mode(0o600)
-                .open(path)?;
+            let mut open_options = OpenOptions::new();
+            open_options.append(true).create(true).mode(0o600);
+            let file = SharedFileWriter::new(path.clone(), open_options)?;
+
+            file_handles.push(file.clone());
+
             tracing_appender::non_blocking(file)
         }
         LogOutput::Journald => unimplemented!(),
@@ -388,25 +392,46 @@ fn create_layer_for_route(
 /// Guards for each worker that drains the logging queue.
 /// When they are dropped, the corresponding log outputs are closed.
 pub struct LogGuard {
+    #[allow(dead_code)]
     guards: Vec<WorkerGuard>,
+    file_handles: Vec<SharedFileWriter>,
+}
+
+impl LogGuard {
+    /// Reopen every file-based log output.
+    /// Intended for logrotate.
+    pub fn reopen_files(&self) {
+        for handle in &self.file_handles {
+            if let Err(err) = handle.reopen() {
+                eprintln!(
+                    "Failed to reopen log file '{}': {err}",
+                    handle.path.display()
+                );
+            }
+        }
+    }
 }
 
 pub fn init(preset: LogPreset) -> anyhow::Result<LogGuard> {
     let config = preset_to_config(preset);
     let mut layers = Vec::new();
-    let mut guards = LogGuard { guards: Vec::new() };
+    let mut guards = Vec::new();
+    let mut file_handles = Vec::new();
 
     // For each subsystem, create one layer per route tagged by the subsystem filter.
     for (subsystem, log_config) in config {
         for route in log_config.routes {
-            let (layer, guard) = create_layer_for_route(subsystem, &route)
+            let (layer, guard) = create_layer_for_route(subsystem, &route, &mut file_handles)
                 .context("Creating a layer for a log route")?;
             layers.push(layer);
-            guards.guards.push(guard);
+            guards.push(guard);
         }
     }
 
     tracing_subscriber::registry().with(layers).init();
 
-    Ok(guards)
+    Ok(LogGuard {
+        guards,
+        file_handles,
+    })
 }

--- a/src/logging/writer.rs
+++ b/src/logging/writer.rs
@@ -1,0 +1,42 @@
+use std::{
+    fs::{File, OpenOptions},
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+/// File writers that can be atomically replaced.
+
+#[derive(Clone)]
+struct SharedFileWriter {
+    file: Arc<Mutex<File>>,
+    open_options: OpenOptions,
+    path: PathBuf,
+}
+
+impl SharedFileWriter {
+    pub fn new(path: PathBuf, open_options: OpenOptions) -> std::io::Result<Self> {
+        let file = Arc::new(Mutex::new(open_options.open(&path)?));
+        Ok(Self {
+            path,
+            file,
+            open_options,
+        })
+    }
+
+    pub fn reopen(&self) -> std::io::Result<()> {
+        let new_file = self.open_options.open(&self.path)?;
+        let mut guard = self.file.lock().unwrap();
+        *guard = new_file;
+        Ok(())
+    }
+}
+
+impl std::io::Write for SharedFileWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.file.lock().unwrap().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.file.lock().unwrap().flush()
+    }
+}

--- a/src/logging/writer.rs
+++ b/src/logging/writer.rs
@@ -4,13 +4,12 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-/// File writers that can be atomically replaced.
-
-#[derive(Clone)]
-struct SharedFileWriter {
+/// File writer that can be atomically replaced.
+#[derive(Debug, Clone)]
+pub struct SharedFileWriter {
     file: Arc<Mutex<File>>,
     open_options: OpenOptions,
-    path: PathBuf,
+    pub path: PathBuf,
 }
 
 impl SharedFileWriter {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand, ValueEnum};
 use std::net::SocketAddr;
+use std::sync::Mutex;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::RwLock;
 use tracing::{debug, error, info, warn};
@@ -281,7 +282,30 @@ async fn main() -> Result<()> {
             bind_rpc_socket,
             log_preset,
         } => {
-            let _guards = logging::init(log_preset.into()).expect("Failed to initialize logging");
+            let log_guard = Arc::new(Mutex::new(
+                logging::init(log_preset.into()).expect("Failed to initialize logging"),
+            ));
+
+            // SIGHUP handler for log rotation.
+            // Reopen every file based log output after logrotate has moved the current files
+            // aside.
+            {
+                let log_guard = log_guard.clone();
+                tokio::spawn(async move {
+                    let mut sig_hup =
+                        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+                            .expect("Failed to set up SIGHUP handler");
+
+                    loop {
+                        sig_hup.recv().await;
+                        tracing::info!("Received SIGHUP, reopening log files");
+                        if let Ok(guard) = log_guard.lock() {
+                            guard.reopen_files();
+                        }
+                    }
+                });
+            }
+
             info!("Reading Portail settings from '{}'", config.display());
             let settings: Arc<config::Settings> = Arc::new(config::init(&config));
 


### PR DESCRIPTION
logrotate is very useful to avoid having tons of logs on your system without compression + rotation across time.
It required one little architectural change inside of Portail, the ability to synchronize all logging to a new file handle once logrotate moves it which happens when logrotate mv a file then kill -SIGHUP $(pidof portail).

Fixes #115.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>