### PR TITLE
Let logging level be reconfigurable at runtime

### DIFF
--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -6,7 +6,6 @@ use tracing::level_filters::LevelFilter;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry,
-    filter::FilterExt,
     layer::{Filter, SubscriberExt},
     reload,
     util::SubscriberInitExt,
@@ -426,6 +425,7 @@ pub fn init(preset: LogPreset) -> anyhow::Result<LogGuard> {
     layers.push(Layer::boxed(reload_layer));
 
     // For each subsystem, create one layer per route tagged by the subsystem filter.
+    // Level filtering is handled by the reload layer above.
     for (subsystem, log_config) in config {
         for route in log_config.routes {
             let (layer, guard) = create_layer_for_route(subsystem, &route, &mut file_handles)

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -8,12 +8,17 @@ use tracing_subscriber::{
     EnvFilter, Layer, Registry,
     filter::FilterExt,
     layer::{Filter, SubscriberExt},
+    reload,
     util::SubscriberInitExt,
 };
 
 use crate::logging::writer::SharedFileWriter;
 
 mod writer;
+
+/// A handle that allows reloading the global log level filter at runtime.
+/// It is used for RPC `SetLogLevel`.
+pub type LogReloadHandle = reload::Handle<EnvFilter, Registry>;
 
 #[derive(Debug, Clone)]
 pub enum LogFormat {
@@ -377,13 +382,7 @@ fn create_layer_for_route(
 
     Ok((
         fmt_layer
-            .with_filter(
-                SubsystemFilter::new(subsystem).and(
-                    EnvFilter::builder()
-                        .with_default_directive(LevelFilter::INFO.into())
-                        .from_env_lossy(),
-                ),
-            )
+            .with_filter(SubsystemFilter::new(subsystem))
             .boxed(),
         guard,
     ))
@@ -395,6 +394,7 @@ pub struct LogGuard {
     #[allow(dead_code)]
     guards: Vec<WorkerGuard>,
     file_handles: Vec<SharedFileWriter>,
+    pub reload_handle: LogReloadHandle,
 }
 
 impl LogGuard {
@@ -418,6 +418,13 @@ pub fn init(preset: LogPreset) -> anyhow::Result<LogGuard> {
     let mut guards = Vec::new();
     let mut file_handles = Vec::new();
 
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    let (reload_layer, reload_handle) = reload::Layer::new(env_filter);
+    layers.push(Layer::boxed(reload_layer));
+
     // For each subsystem, create one layer per route tagged by the subsystem filter.
     for (subsystem, log_config) in config {
         for route in log_config.routes {
@@ -433,5 +440,6 @@ pub fn init(preset: LogPreset) -> anyhow::Result<LogGuard> {
     Ok(LogGuard {
         guards,
         file_handles,
+        reload_handle,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -357,7 +357,12 @@ async fn main() -> Result<()> {
 
             let (proxy_fut, rpc_fut) = (
                 proxy::start(proxy_rt, tcp_listener, effective_max_conn),
-                rpc::start(settings.clone(), state.clone(), rpc_listener),
+                rpc::start(
+                    settings.clone(),
+                    state.clone(),
+                    rpc_listener,
+                    log_guard.lock().unwrap().reload_handle.clone(),
+                ),
             );
 
             if let Err(e) = sd_notify_ready() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,12 @@ enum RpcCommands {
         backend_id: String,
     },
 
+    /// Change the global log level of the daemon at runtime.
+    SetLogLevel {
+        /// Log level directive (e.g. "debug", "trace", "warn", "portail=debug")
+        level: String,
+    },
+
     /// Unset the default backend via RPC.
     UnsetDefaultBackend,
 
@@ -194,6 +200,26 @@ async fn main() -> Result<()> {
                             std::io::stdout(),
                             &serde_json::json!({
                                 "success": true
+                            }),
+                        )
+                        .context("While writing JSON")?;
+                    }
+                }
+
+                RpcCommands::SetLogLevel { level } => {
+                    connection.set_log_level(&level)
+                        .await
+                        .context("During Varlink low-level communications. Are you using same versions of Portail on both sides?")?
+                        .context("Failed to set log level")?;
+
+                    if !json {
+                        println!("Log level changed to '{}'.", level);
+                    } else {
+                        serde_json::to_writer(
+                            std::io::stdout(),
+                            &serde_json::json!({
+                                "success": true,
+                                "level": level
                             }),
                         )
                         .context("While writing JSON")?;

--- a/src/rpc/fr.gouv.portail.control.varlink
+++ b/src/rpc/fr.gouv.portail.control.varlink
@@ -4,6 +4,7 @@ method SetDefaultBackend(backend_id: ?string) -> ()
 method GetCurrentBackend() -> (backend_id: string)
 method ListBackends() -> (backends: []BackendListItem)
 method UpdateDynamicBackend(backend_id: string, backend_spec: DynamicBackendSpec) -> ()
+method SetLogLevel(level: string) -> ()
 
 type DynamicBackendSpec (
   target_address: string,
@@ -32,3 +33,5 @@ error InvalidBackend (reason: string)
 error ImmutableBackend ()
 # Client is not allowed to call this method.
 error PermissionDenied ()
+# Log level was rejected by the API
+error InvalidLogLevel (reason: string)

--- a/src/rpc/fr_gouv_portail_control.rs
+++ b/src/rpc/fr_gouv_portail_control.rs
@@ -29,6 +29,9 @@ pub enum ControlError {
     /// This backend is not dynamic and cannot be changed
     ImmutableBackend,
     PermissionDenied,
+    InvalidLogLevel {
+        reason: String,
+    },
 }
 
 impl Display for ControlError {
@@ -60,6 +63,10 @@ impl Display for ControlError {
             Self::InvalidBackend { reason } => {
                 f.write_fmt(format_args!("Backend passed had invalid data: {}", reason))?
             }
+
+            Self::InvalidLogLevel { reason } => {
+                f.write_fmt(format_args!("Invalid log level: {}", reason))?
+            }
         }
 
         Ok(())
@@ -84,6 +91,7 @@ pub trait Control {
         backend_id: &str,
         backend_spec: DynamicBackendSpec,
     ) -> zlink::Result<Result<(), ControlError>>;
+    async fn set_log_level(&mut self, level: &str) -> zlink::Result<Result<(), ControlError>>;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, zlink::introspect::Type)]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     config::{BackendSettings, KnownBackend, Settings},
+    logging::LogReloadHandle,
     rpc::fr_gouv_portail_control::{
         BackendListItem, ControlError, DynamicBackendSpec, GetCurrentBackendOutput,
         ListBackendsOutput,
@@ -34,11 +35,20 @@ fn resolve_numeric_groups_to_names(gids: Vec<zlink::connection::Gid>) -> HashSet
 pub struct Control {
     settings: Arc<Settings>,
     state: Arc<RwLock<State>>,
+    log_reload_handle: LogReloadHandle,
 }
 
 impl Control {
-    pub fn new(settings: Arc<Settings>, state: Arc<RwLock<State>>) -> Self {
-        Self { settings, state }
+    pub fn new(
+        settings: Arc<Settings>,
+        state: Arc<RwLock<State>>,
+        log_reload_handle: LogReloadHandle,
+    ) -> Self {
+        Self {
+            settings,
+            state,
+            log_reload_handle,
+        }
     }
 }
 
@@ -240,10 +250,11 @@ pub async fn start(
     settings: Arc<Settings>,
     state: Arc<RwLock<State>>,
     listener: UnixListener,
+    log_reload_handle: LogReloadHandle,
 ) -> anyhow::Result<()> {
     let server: Server<zlink::tokio::unix::Listener, _> = Server::new(
         listener.into(),
-        Control::new(settings.clone(), state.clone()),
+        Control::new(settings.clone(), state.clone(), log_reload_handle),
     );
 
     info!("started Varlink service");

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -9,7 +9,8 @@ use crate::{
 };
 use std::{collections::HashSet, sync::Arc};
 use tokio::{net::UnixListener, sync::RwLock};
-use tracing::{debug, info, warn};
+use tracing::{debug, info, level_filters::LevelFilter, warn};
+use tracing_subscriber::EnvFilter;
 use zlink::{
     Server,
     connection::{Socket, socket::FetchPeerCredentials},
@@ -139,6 +140,37 @@ where
             state.default_backend = None;
         }
 
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all, fields(subsystem = "rpc", level = %level))]
+    async fn set_log_level(
+        &mut self,
+        level: &str,
+        #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
+    ) -> Result<(), ControlError> {
+        self.check_authorization(conn, self.settings.rpc.admin_groups.iter())
+            .await?;
+
+        let new_filter = EnvFilter::builder()
+            .with_default_directive(LevelFilter::INFO.into())
+            .parse(level)
+            .map_err(|e| ControlError::InvalidLogLevel {
+                reason: e.to_string(),
+            })?;
+
+        info!(
+            new_level = %level,
+            "Reloading global log levels"
+        );
+
+        self.log_reload_handle
+            .reload(new_filter)
+            .map_err(|e| ControlError::InvalidLogLevel {
+                reason: e.to_string(),
+            })?;
+
+        info!("Global log level reloaded successfully");
         Ok(())
     }
 


### PR DESCRIPTION
`portail rpc set-log-level debug` is now possible.
The level supports also the general Rust directive syntax, so `portail rpc set-log-level portail::proxy=trace` is equally possible.

Fixes #112.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>